### PR TITLE
feat(client): adding initial otel to client

### DIFF
--- a/bedrock/client/client.go
+++ b/bedrock/client/client.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // StreamReader is the subset of the Converse stream API used by the model provider.
@@ -29,13 +32,31 @@ type RuntimeAPI interface {
 	) (StreamReader, error)
 }
 
+// Option configures an adapter created with [NewFromClient].
+type Option func(*adapter)
+
+// WithTracer attaches an OpenTelemetry [trace.Tracer] used to record spans for
+// [RuntimeAPI.Converse] and [RuntimeAPI.ConverseStream].
+func WithTracer(tracer trace.Tracer) Option {
+	return func(a *adapter) {
+		a.tracer = tracer
+	}
+}
+
 type adapter struct {
-	inner *bedrockruntime.Client
+	inner  *bedrockruntime.Client
+	tracer trace.Tracer
 }
 
 // NewFromClient wraps a [bedrockruntime.Client] as [RuntimeAPI].
-func NewFromClient(c *bedrockruntime.Client) RuntimeAPI {
-	return &adapter{inner: c}
+func NewFromClient(c *bedrockruntime.Client, opts ...Option) RuntimeAPI {
+	a := &adapter{inner: c}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(a)
+		}
+	}
+	return a
 }
 
 func (c *adapter) Converse(
@@ -43,6 +64,22 @@ func (c *adapter) Converse(
 	params *bedrockruntime.ConverseInput,
 	optFns ...func(*bedrockruntime.Options),
 ) (*bedrockruntime.ConverseOutput, error) {
+	if c.tracer != nil {
+		ctx, span := c.tracer.Start(ctx, "bedrock.Converse",
+			trace.WithSpanKind(trace.SpanKindClient),
+		)
+		defer span.End()
+		if params != nil && params.ModelId != nil && *params.ModelId != "" {
+			span.SetAttributes(attribute.String("aws.bedrock.model_id", *params.ModelId))
+		}
+		out, err := c.inner.Converse(ctx, params, optFns...)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, err
+		}
+		return out, nil
+	}
 	return c.inner.Converse(ctx, params, optFns...)
 }
 
@@ -51,6 +88,22 @@ func (c *adapter) ConverseStream(
 	params *bedrockruntime.ConverseStreamInput,
 	optFns ...func(*bedrockruntime.Options),
 ) (StreamReader, error) {
+	if c.tracer != nil {
+		ctx, span := c.tracer.Start(ctx, "bedrock.ConverseStream",
+			trace.WithSpanKind(trace.SpanKindClient),
+		)
+		defer span.End()
+		if params != nil && params.ModelId != nil && *params.ModelId != "" {
+			span.SetAttributes(attribute.String("aws.bedrock.model_id", *params.ModelId))
+		}
+		out, err := c.inner.ConverseStream(ctx, params, optFns...)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, err
+		}
+		return out.GetStream(), nil
+	}
 	out, err := c.inner.ConverseStream(ctx, params, optFns...)
 	if err != nil {
 		return nil, err

--- a/examples/bedrock-chat/main.go
+++ b/examples/bedrock-chat/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"go.opentelemetry.io/otel"
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
 	"google.golang.org/adk/runner"
@@ -50,7 +51,8 @@ func main() {
 	}
 
 	br := bedrockruntime.NewFromConfig(awsCfg)
-	llm, err := bedrock.NewWithAPI(modelID, client.NewFromClient(br))
+	tr := otel.Tracer("github.com/craigh33/adk-go-bedrock/examples/bedrock-chat")
+	llm, err := bedrock.NewWithAPI(modelID, client.NewFromClient(br, client.WithTracer(tr)))
 	if err != nil {
 		log.Fatalf("bedrock model: %v", err)
 	}

--- a/examples/bedrock-web-ui/main.go
+++ b/examples/bedrock-web-ui/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"go.opentelemetry.io/otel"
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
 	"google.golang.org/adk/cmd/launcher"
@@ -43,7 +44,8 @@ func main() {
 	}
 
 	br := bedrockruntime.NewFromConfig(awsCfg)
-	llm, err := bedrock.NewWithAPI(modelID, client.NewFromClient(br))
+	tr := otel.Tracer("github.com/craigh33/adk-go-bedrock/examples/bedrock-web-ui")
+	llm, err := bedrock.NewWithAPI(modelID, client.NewFromClient(br, client.WithTracer(tr)))
 	if err != nil {
 		log.Fatalf("bedrock model: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.3
+	go.opentelemetry.io/otel v1.40.0
+	go.opentelemetry.io/otel/trace v1.40.0
 	google.golang.org/adk v1.0.0
 	google.golang.org/genai v1.51.0
 )
@@ -48,7 +50,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.40.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
-	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.16.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.39.0 // indirect
@@ -56,7 +57,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.16.0 // indirect
-	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect


### PR DESCRIPTION
Adding in initial OTEL support. 

Otel supported in client using optional tracer. Tracer initalised by calling applicaton, library has no knowledge of OTEL implementation. 