### PR TITLE
feat: add CI workflows and GoReleaser configuration

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,0 +1,23 @@
+name: CI Build
+
+on:
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+          args: --timeout=5m
+
+      - name: Unit tests
+        run: go test ./... -count=1

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -1,0 +1,32 @@
+name: CI Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean${{ github.ref_type == 'branch' && ' --snapshot' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,18 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - skip: true
+
+source:
+  enabled: true
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,15 +16,30 @@ repos:
         stages: [commit-msg]
         args: [feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert]
 
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.10.1
+    hooks:
+      - id: golangci-lint
+        name: Lint
+        args:
+          - '--config=.golangci.yaml'
+          - '--new'
+          - '--verbose'
+        exclude: |
+          (?x)^(
+                api/.*|
+                build/.*|
+                deployments/.*|
+                docs/.*|
+                mocks/.*|
+                scripts/.*
+            )$
+        types:
+          - go
+        stages: [ pre-commit ]
+
   - repo: local
     hooks:
-      - id: lint
-        name: golangci-lint
-        entry: make lint
-        language: system
-        pass_filenames: false
-        files: ^/*
-
       - id: gitleaks
         name: gitleaks (staged diff scan)
         entry: gitleaks git . --staged --redact


### PR DESCRIPTION
Updates pre-commit
Add ci-build.yaml to run UT and linter on PR push.
Add ci-release.yaml to run goreleaser for versioning on push to main.