### PR TITLE
fix: Amend CI flow to create tag then run goreleaser

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -1,11 +1,8 @@
 name: CI Release
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
+  release:
+    types: [created]
 
 permissions:
   contents: write

--- a/.github/workflows/ci-tag.yaml.yml
+++ b/.github/workflows/ci-tag.yaml.yml
@@ -1,0 +1,30 @@
+name: ci-tag.yaml
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Bumps version, creates tag, and creates a GitHub Release
+      - name: Bump version and create release tag
+        uses: mathieudutour/github-tag-action@v6.2
+        id: tag
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+          default_bump: patch
+          tag_prefix: "v"
+
+      - name: Show created tag
+        run: |
+          echo "new_tag=${{ steps.tagger.outputs.new_tag }}"
+          echo "changelog=${{ steps.tagger.outputs.changelog }}"

--- a/.github/workflows/ci-tag.yaml.yml
+++ b/.github/workflows/ci-tag.yaml.yml
@@ -26,5 +26,5 @@ jobs:
 
       - name: Show created tag
         run: |
-          echo "new_tag=${{ steps.tagger.outputs.new_tag }}"
-          echo "changelog=${{ steps.tagger.outputs.changelog }}"
+          echo "new_tag=${{ steps.tag.outputs.new_tag }}"
+          echo "changelog=${{ steps.tag.outputs.changelog }}"

--- a/.github/workflows/ci-tag.yaml.yml
+++ b/.github/workflows/ci-tag.yaml.yml
@@ -1,4 +1,4 @@
-name: ci-tag.yaml
+name: ci-tag
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Amend the CI flow so that we create a tag and then run goreleaser