### PR TITLE
feat: Function tool support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ go.work.sum
 # .vscode/
 # Added by goreleaser init:
 dist/
+
+.DS_Store
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Each example has its own `README.md` and `Makefile`:
 - [`examples/bedrock-chat`](examples/bedrock-chat): runner-based chat example.
 - [`examples/bedrock-mcp`](examples/bedrock-mcp): MCP support via ADK's `mcptoolset` with an in-memory MCP server ([MCP support](#mcp-support)).
 - [`examples/bedrock-tool-calling`](examples/bedrock-tool-calling): tool-calling agent example with function declarations.
+- [`examples/bedrock-function-tool`](examples/bedrock-function-tool): ADK `functiontool` with typed args/results and `llmagent` + runner (contrasts with hand-written `genai.Tool` in bedrock-tool-calling).
 - [`examples/bedrock-image-gen`](examples/bedrock-image-gen): ADK runner with the [`imagegenerator`](tools/imagegenerator) tool—Nova Canvas image generation via Bedrock `InvokeModel` and artifact storage.
 - [`examples/bedrock-stream`](examples/bedrock-stream): direct streaming example using `GenerateContent(..., true)`.
 - [`examples/bedrock-tool-variants`](examples/bedrock-tool-variants): function declaration support plus early detection of non-function ADK tool variants that Bedrock does not currently support.

--- a/examples/bedrock-function-tool/Makefile
+++ b/examples/bedrock-function-tool/Makefile
@@ -1,0 +1,4 @@
+.PHONY: run
+
+run:
+	go run . $(PROMPT)

--- a/examples/bedrock-function-tool/README.md
+++ b/examples/bedrock-function-tool/README.md
@@ -4,7 +4,7 @@ This example runs an ADK `llmagent` with a `functiontool`-defined tool against t
 
 ## Prerequisites
 
-- `BEDROCK_MODEL_ID` set to a Bedrock model ID or inference profile ARN (must support tool use)
+- Optional: `BEDROCK_MODEL_ID` may be set to a Bedrock model ID or inference profile ARN that supports tool use; if unset, the example falls back to its default model ID
 - AWS credentials configured via the default chain
 - AWS region configured (for example `AWS_REGION=us-east-1`)
 

--- a/examples/bedrock-function-tool/README.md
+++ b/examples/bedrock-function-tool/README.md
@@ -1,0 +1,21 @@
+# bedrock-function-tool example
+
+This example runs an ADK `llmagent` with a `functiontool`-defined tool against the Bedrock Converse provider. The tool uses typed arguments and return values (JSON schema is inferred and sent to the model as `parametersJsonSchema`).
+
+## Prerequisites
+
+- `BEDROCK_MODEL_ID` set to a Bedrock model ID or inference profile ARN (must support tool use)
+- AWS credentials configured via the default chain
+- AWS region configured (for example `AWS_REGION=us-east-1`)
+
+## Run
+
+```bash
+make -C examples/bedrock-function-tool run
+```
+
+Or pass a custom prompt:
+
+```bash
+make -C examples/bedrock-function-tool run PROMPT='What is the weather in Paris?'
+```

--- a/examples/bedrock-function-tool/main.go
+++ b/examples/bedrock-function-tool/main.go
@@ -1,0 +1,154 @@
+// Bedrock function-tool example for adk-go: uses ADK functiontool with a typed handler
+// (ParametersJsonSchema) and the Bedrock Converse provider. Set BEDROCK_MODEL_ID and
+// authenticate with AWS using the default credential chain. Optionally set AWS_REGION. Run:
+//
+//	go run ./examples/bedrock-function-tool
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/genai"
+
+	"github.com/craigh33/adk-go-bedrock/bedrock"
+	"github.com/craigh33/adk-go-bedrock/examples/internal/exampletrace"
+)
+
+// WeatherArgs is the JSON input the model supplies for get_weather.
+type WeatherArgs struct {
+	Location string `json:"location"`
+}
+
+// WeatherResult is returned to the model after the tool runs.
+type WeatherResult struct {
+	Location    string    `json:"location"`
+	Temperature int       `json:"temperature"`
+	Condition   string    `json:"condition"`
+	Humidity    int       `json:"humidity"`
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+// GetWeather simulates a weather API and returns structured data for the model.
+//
+//nolint:gosec // G404: math/rand for non-cryptographic fake weather only.
+func GetWeather(_ tool.Context, args WeatherArgs) (WeatherResult, error) {
+	temperatures := []int{-10, -5, 0, 5, 10, 15, 20, 25, 30, 35}
+	conditions := []string{"sunny", "cloudy", "rainy", "snowy", "windy"}
+
+	return WeatherResult{
+		Location:    args.Location,
+		Temperature: temperatures[rand.IntN(len(temperatures))],
+		Condition:   conditions[rand.IntN(len(conditions))],
+		Humidity:    rand.IntN(61) + 30, // 30–90
+		Timestamp:   time.Now(),
+	}, nil
+}
+
+func main() {
+	ctx := context.Background()
+
+	// Default AWS authentication: same resolution order as the AWS CLI — env vars
+	// (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN), shared credentials
+	// file, config file (including profile and region), SSO token provider, IMDS on EC2, etc.
+	var loadOpts []func(*config.LoadOptions) error
+	if r := strings.TrimSpace(os.Getenv("AWS_REGION")); r != "" {
+		loadOpts = append(loadOpts, config.WithRegion(r))
+	}
+	awsCfg, err := config.LoadDefaultConfig(ctx, loadOpts...)
+	if err != nil {
+		log.Fatalf("load AWS config (check credentials and AWS_PROFILE): %v", err)
+	}
+	if awsCfg.Region == "" {
+		log.Fatal("AWS region is unset: set AWS_REGION or add region to your ~/.aws/config profile")
+	}
+
+	modelID := os.Getenv("BEDROCK_MODEL_ID")
+	if modelID == "" {
+		log.Println("BEDROCK_MODEL_ID is required (e.g. eu.amazon.nova-2-lite-v1:0) using default model")
+		modelID = "eu.amazon.nova-2-lite-v1:0"
+	}
+
+	tp, shutdownTP, err := exampletrace.TracerProvider(ctx)
+	if err != nil {
+		log.Fatalf("tracer provider: %v", err)
+	}
+	defer func() { _ = shutdownTP(context.Background()) }()
+
+	br := bedrockruntime.NewFromConfig(awsCfg)
+	llm, err := bedrock.NewWithAPI(modelID, bedrock.NewRuntimeAPI(br, bedrock.WithTracerProvider(tp)))
+	if err != nil {
+		log.Panicf("bedrock model: %v", err)
+	}
+
+	getWeatherTool, err := functiontool.New(functiontool.Config{
+		Name:        "get_weather",
+		Description: "Get weather information for a location (temperature, condition, humidity, timestamp).",
+	}, GetWeather)
+	if err != nil {
+		//nolint:gocritic // exitAfterDefer: example skips tracer shutdown on tool setup failure
+		log.Fatalf("function tool: %v", err)
+	}
+
+	a, err := llmagent.New(llmagent.Config{
+		Name:        "weather_agent",
+		Model:       llm,
+		Description: "Weather agent.",
+		Instruction: `You are a helpful assistant that provides weather information for a given location. Use the get_weather tool to fetch the current weather data, including temperature, condition, humidity, and timestamp. Always provide the most accurate and up-to-date information based on the user's request.`,
+		GenerateContentConfig: &genai.GenerateContentConfig{
+			MaxOutputTokens: 512,
+		},
+		Tools: []tool.Tool{getWeatherTool},
+	})
+	if err != nil {
+		log.Panicf("agent: %v", err)
+	}
+
+	r, err := runner.New(runner.Config{
+		AppName:           "bedrock-function-tool-example",
+		Agent:             a,
+		SessionService:    session.InMemoryService(),
+		AutoCreateSession: true,
+	})
+	if err != nil {
+		log.Panicf("runner: %v", err)
+	}
+
+	userMsg := "What is the weather like in Seattle? Summarize the tool output briefly."
+	if len(os.Args) > 1 {
+		userMsg = strings.Join(os.Args[1:], " ")
+	}
+
+	for ev, err := range r.Run(ctx, "local-user", "demo-session", genai.NewContentFromText(userMsg, genai.RoleUser), agent.RunConfig{}) {
+		if err != nil {
+			log.Panicf("run: %v", err)
+		}
+		if ev.Author != a.Name() {
+			continue
+		}
+		if ev.LLMResponse.Partial {
+			continue
+		}
+		if ev.LLMResponse.Content != nil {
+			for _, p := range ev.LLMResponse.Content.Parts {
+				if p.Text != "" {
+					fmt.Print(p.Text)
+				}
+			}
+			fmt.Println()
+		}
+	}
+}

--- a/internal/mappers/tools.go
+++ b/internal/mappers/tools.go
@@ -90,7 +90,7 @@ func unsupportedToolVariantsFromGenai(t *genai.Tool) []string {
 
 func functionParametersToToolInputSchema(fd *genai.FunctionDeclaration) (types.ToolInputSchema, error) {
 	if fd.ParametersJsonSchema != nil {
-		schema, err := normalizaSchema(fd.ParametersJsonSchema)
+		schema, err := normalizeSchema(fd.ParametersJsonSchema)
 		if err != nil {
 			return nil, err
 		}
@@ -139,12 +139,12 @@ func normalizeSchemaTypes(v any) {
 	}
 }
 
-// normalizaSchema turns ParametersJsonSchema into a JSON object map for Bedrock Converse.
+// normalizeSchema turns ParametersJsonSchema into a JSON object map for Bedrock Converse.
 // ADK FunctionTool supplies this field as arbitrary JSON (often a struct or other non-map
 // value after decoding). Bedrock's document layer expects a map[string]any; passing the
 // raw value through can fail or encode incorrectly, so we round-trip through JSON when
 // the value is not already map[string]any.
-func normalizaSchema(schema any) (map[string]any, error) {
+func normalizeSchema(schema any) (map[string]any, error) {
 	switch s := schema.(type) {
 	case map[string]any:
 		return s, nil

--- a/internal/mappers/tools.go
+++ b/internal/mappers/tools.go
@@ -90,7 +90,11 @@ func unsupportedToolVariantsFromGenai(t *genai.Tool) []string {
 
 func functionParametersToToolInputSchema(fd *genai.FunctionDeclaration) (types.ToolInputSchema, error) {
 	if fd.ParametersJsonSchema != nil {
-		return &types.ToolInputSchemaMemberJson{Value: brdoc.NewLazyDocument(fd.ParametersJsonSchema)}, nil
+		schema, err := normalizaSchema(fd.ParametersJsonSchema)
+		if err != nil {
+			return nil, err
+		}
+		return &types.ToolInputSchemaMemberJson{Value: brdoc.NewLazyDocument(schema)}, nil
 	}
 	if fd.Parameters == nil {
 		return &types.ToolInputSchemaMemberJson{
@@ -132,5 +136,27 @@ func normalizeSchemaTypes(v any) {
 		for _, item := range m {
 			normalizeSchemaTypes(item)
 		}
+	}
+}
+
+// normalizaSchema turns ParametersJsonSchema into a JSON object map for Bedrock Converse.
+// ADK FunctionTool supplies this field as arbitrary JSON (often a struct or other non-map
+// value after decoding). Bedrock's document layer expects a map[string]any; passing the
+// raw value through can fail or encode incorrectly, so we round-trip through JSON when
+// the value is not already map[string]any.
+func normalizaSchema(schema any) (map[string]any, error) {
+	switch s := schema.(type) {
+	case map[string]any:
+		return s, nil
+	default:
+		bytes, err := json.Marshal(s)
+		if err != nil {
+			return nil, fmt.Errorf("bedrock: failed to marshal schema: %w", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(bytes, &m); err != nil {
+			return nil, fmt.Errorf("bedrock: failed to unmarshal schema: %w", err)
+		}
+		return m, nil
 	}
 }

--- a/internal/mappers/tools_test.go
+++ b/internal/mappers/tools_test.go
@@ -187,10 +187,10 @@ func TestToolConfigurationFromGenai_MultipleToolVariantsReturnUnsupportedError(t
 	}
 }
 
-func TestNormalizaSchema_MapPassthrough(t *testing.T) {
+func TestNormalizeSchema_MapPassthrough(t *testing.T) {
 	t.Parallel()
 	in := map[string]any{"type": "object", "properties": map[string]any{"x": map[string]any{"type": "string"}}}
-	got, err := normalizaSchema(in)
+	got, err := normalizeSchema(in)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestNormalizaSchema_MapPassthrough(t *testing.T) {
 	delete(in, "_probe")
 }
 
-func TestNormalizaSchema_StructRoundTripsToMap(t *testing.T) {
+func TestNormalizeSchema_StructRoundTripsToMap(t *testing.T) {
 	t.Parallel()
 	// Simulates ADK FunctionTool / genai where parametersJsonSchema is not map[string]any.
 	type nested struct {
@@ -221,7 +221,7 @@ func TestNormalizaSchema_StructRoundTripsToMap(t *testing.T) {
 			"n": {Type: "NUMBER", Nested: nested{Min: 1}, Ignored: "skip"},
 		},
 	}
-	got, err := normalizaSchema(schema)
+	got, err := normalizeSchema(schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,10 +248,10 @@ func TestNormalizaSchema_StructRoundTripsToMap(t *testing.T) {
 	}
 }
 
-func TestNormalizaSchema_UnmarshalableJSONReturnsError(t *testing.T) {
+func TestNormalizeSchema_UnmarshalableJSONReturnsError(t *testing.T) {
 	t.Parallel()
 	ch := make(chan int)
-	_, err := normalizaSchema(ch)
+	_, err := normalizeSchema(ch)
 	if err == nil || !strings.Contains(err.Error(), "marshal") {
 		t.Fatalf("expected marshal error, got: %v", err)
 	}

--- a/internal/mappers/tools_test.go
+++ b/internal/mappers/tools_test.go
@@ -1,6 +1,7 @@
 package mappers
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -183,5 +184,112 @@ func TestToolConfigurationFromGenai_MultipleToolVariantsReturnUnsupportedError(t
 		if !strings.Contains(err.Error(), name) {
 			t.Fatalf("expected error to mention %s, got: %v", name, err)
 		}
+	}
+}
+
+func TestNormalizaSchema_MapPassthrough(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{"type": "object", "properties": map[string]any{"x": map[string]any{"type": "string"}}}
+	got, err := normalizaSchema(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got["_probe"] = 1
+	if in["_probe"] != 1 {
+		t.Fatal("expected same map backing store for map[string]any input")
+	}
+	delete(in, "_probe")
+}
+
+func TestNormalizaSchema_StructRoundTripsToMap(t *testing.T) {
+	t.Parallel()
+	// Simulates ADK FunctionTool / genai where parametersJsonSchema is not map[string]any.
+	type nested struct {
+		Min float64 `json:"minimum"`
+	}
+	type propSchema struct {
+		Type    string `json:"type"`
+		Nested  nested `json:"meta"`
+		Ignored string `json:"-"`
+	}
+	schema := struct {
+		Type       string                `json:"type"`
+		Properties map[string]propSchema `json:"properties"`
+	}{
+		Type: "object",
+		Properties: map[string]propSchema{
+			"n": {Type: "NUMBER", Nested: nested{Min: 1}, Ignored: "skip"},
+		},
+	}
+	got, err := normalizaSchema(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["type"] != "object" {
+		t.Fatalf("type: got %v", got["type"])
+	}
+	props, ok := got["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties: got %T", got["properties"])
+	}
+	n, ok := props["n"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties.n: got %T", props["n"])
+	}
+	if n["type"] != "NUMBER" {
+		t.Fatalf("properties.n.type: got %v", n["type"])
+	}
+	meta, ok := n["meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("meta: got %T", n["meta"])
+	}
+	if meta["minimum"] != float64(1) {
+		t.Fatalf("meta.minimum: got %v", meta["minimum"])
+	}
+}
+
+func TestNormalizaSchema_UnmarshalableJSONReturnsError(t *testing.T) {
+	t.Parallel()
+	ch := make(chan int)
+	_, err := normalizaSchema(ch)
+	if err == nil || !strings.Contains(err.Error(), "marshal") {
+		t.Fatalf("expected marshal error, got: %v", err)
+	}
+}
+
+func TestFunctionParametersToToolInputSchema_ParametersJsonSchemaStruct(t *testing.T) {
+	t.Parallel()
+	type item struct {
+		Type string `json:"type"`
+	}
+	fd := &genai.FunctionDeclaration{
+		Name:        "fn",
+		Description: "d",
+		ParametersJsonSchema: struct {
+			Items item `json:"items"`
+		}{Items: item{Type: "STRING"}},
+	}
+	schema, err := functionParametersToToolInputSchema(fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonMember, ok := schema.(*types.ToolInputSchemaMemberJson)
+	if !ok {
+		t.Fatalf("got %T", schema)
+	}
+	raw, err := jsonMember.Value.MarshalSmithyDocument()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	items, ok := decoded["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("items: got %T", decoded["items"])
+	}
+	if items["type"] != "STRING" {
+		t.Fatalf("items.type: got %v", items["type"])
 	}
 }


### PR DESCRIPTION
## Summary

#52 

Adds support for ADK functiontool-backed tool calls by ensuring ParametersJsonSchema can be converted into a Bedrock-compatible JSON object schema, plus an end-to-end example.

Changes:

Convert FunctionDeclaration.ParametersJsonSchema into map[string]any before building Bedrock ToolInputSchema.
Add unit tests covering schema normalization and the new mapping path.
Introduce a new runnable example demonstrating functiontool usage with Bedrock.

## Type of change

<!-- Mark relevant items with an x like [x]. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / enhancement (non-breaking change that adds behavior)
- [ ] Breaking change (fix or feature that could break existing callers)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor / test / chore (no user-visible behavior change)

## Testing

<!-- How did you verify this? Commands run, manual scenarios, etc. -->

- [x] `make test`
- [x] `make lint` (or equivalent local golangci-lint)
- [x] Example Created/Updated (mention what example was used in the summary)

## Checklist

- [x] I ran **`pre-commit run --all-files`** (or equivalent local hooks).
- [x] My change follows existing patterns in this repository (naming, layout, error handling).
- [x] I updated docs when behavior, setup, or public API surface changed (if applicable).
- [x] I considered backwards compatibility for library consumers (if applicable).

## Related issues

(Issue #52 )[https://github.com/craigh33/adk-go-bedrock/issues/52]
