### PR TITLE
feat: add request-side Bedrock guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ These runnable programs show how to wire `adk-go-bedrock` into ADK agents: chat 
 - [`examples/bedrock-prompt-cache`](examples/bedrock-prompt-cache): `ModelOption` / Bedrock prompt caching for fewer repeated tokens (see AWS prompt caching docs).
 - [`examples/bedrock-document`](examples/bedrock-document): CLI to debug document uploads (`-dry-run` mapper check, optional `-combined` / `-stream`).
 - [`examples/bedrock-guardrails`](examples/bedrock-guardrails): safety assessments, content filtering, and guardrail metadata handling.
+- [`examples/bedrock-request-guardrail`](examples/bedrock-request-guardrail): request-side Bedrock guardrail configuration via `ModelOption`.
 - [`examples/bedrock-system-instruction`](examples/bedrock-system-instruction): system instructions for role definition, output formatting, and behavioral control.
 - [`examples/bedrock-web-ui`](examples/bedrock-web-ui): ADK local web UI launcher.
 

--- a/bedrock/converse.go
+++ b/bedrock/converse.go
@@ -158,9 +158,13 @@ type Options struct {
 
 // Model implements [model.LLM] using Amazon Bedrock Runtime Converse / ConverseStream.
 type Model struct {
-	modelID           string
-	api               RuntimeAPI
-	cacheSystemPrompt bool
+	modelID             string
+	api                 RuntimeAPI
+	cacheSystemPrompt   bool
+	guardrailConfigured bool
+	guardrailIdentifier string
+	guardrailVersion    string
+	guardrailTrace      types.GuardrailTrace
 }
 
 // New creates a [Model] using the default AWS configuration chain and a new
@@ -192,7 +196,48 @@ func NewWithAPI(modelID string, api RuntimeAPI, opts ...ModelOption) (*Model, er
 	for _, opt := range opts {
 		opt(m)
 	}
+	if err := m.validateGuardrail(); err != nil {
+		return nil, err
+	}
 	return m, nil
+}
+
+func (m *Model) validateGuardrail() error {
+	if !m.guardrailConfigured {
+		return nil
+	}
+	if m.guardrailIdentifier == "" {
+		return errors.New("bedrock guardrail identifier is required")
+	}
+	if m.guardrailVersion == "" {
+		return errors.New("bedrock guardrail version is required")
+	}
+	if !slices.Contains(types.GuardrailTrace("").Values(), m.guardrailTrace) {
+		return fmt.Errorf("unsupported bedrock guardrail trace: %q", m.guardrailTrace)
+	}
+	return nil
+}
+
+func (m *Model) guardrailConfig() *types.GuardrailConfiguration {
+	if !m.guardrailConfigured {
+		return nil
+	}
+	return &types.GuardrailConfiguration{
+		GuardrailIdentifier: &m.guardrailIdentifier,
+		GuardrailVersion:    &m.guardrailVersion,
+		Trace:               m.guardrailTrace,
+	}
+}
+
+func (m *Model) guardrailStreamConfig() *types.GuardrailStreamConfiguration {
+	if !m.guardrailConfigured {
+		return nil
+	}
+	return &types.GuardrailStreamConfiguration{
+		GuardrailIdentifier: &m.guardrailIdentifier,
+		GuardrailVersion:    &m.guardrailVersion,
+		Trace:               m.guardrailTrace,
+	}
 }
 
 // Name returns the configured model identifier (see [New]).
@@ -237,6 +282,7 @@ func (m *Model) generateUnary(
 			yield(nil, err)
 			return
 		}
+		in.GuardrailConfig = m.guardrailConfig()
 		out, err := m.api.Converse(ctx, in)
 		if err != nil {
 			yield(nil, err)
@@ -259,6 +305,7 @@ func (m *Model) generateStream(
 			yield(nil, err)
 			return
 		}
+		in.GuardrailConfig = m.guardrailStreamConfig()
 		stream, err := m.api.ConverseStream(ctx, in)
 		if err != nil {
 			yield(nil, err)

--- a/bedrock/converse_test.go
+++ b/bedrock/converse_test.go
@@ -25,9 +25,11 @@ import (
 type fakeAPI struct {
 	converseOut *bedrockruntime.ConverseOutput
 	converseErr error
+	converseIn  *bedrockruntime.ConverseInput
 
 	stream    StreamReader
 	streamErr error
+	streamIn  *bedrockruntime.ConverseStreamInput
 }
 
 func (f *fakeAPI) Converse(
@@ -36,8 +38,8 @@ func (f *fakeAPI) Converse(
 	optFns ...func(*bedrockruntime.Options),
 ) (*bedrockruntime.ConverseOutput, error) {
 	_ = ctx
-	_ = params
 	_ = optFns
+	f.converseIn = params
 	if f.converseErr != nil {
 		return nil, f.converseErr
 	}
@@ -50,8 +52,8 @@ func (f *fakeAPI) ConverseStream(
 	optFns ...func(*bedrockruntime.Options),
 ) (StreamReader, error) {
 	_ = ctx
-	_ = params
 	_ = optFns
+	f.streamIn = params
 	if f.streamErr != nil {
 		return nil, f.streamErr
 	}
@@ -66,6 +68,20 @@ type fakeStream struct {
 func (f *fakeStream) Events() <-chan types.ConverseStreamOutput { return f.ch }
 func (f *fakeStream) Close() error                              { return nil }
 func (f *fakeStream) Err() error                                { return f.err }
+
+func fakeTextOutput(text string) *bedrockruntime.ConverseOutput {
+	return &bedrockruntime.ConverseOutput{
+		Output: &types.ConverseOutputMemberMessage{
+			Value: types.Message{
+				Role: types.ConversationRoleAssistant,
+				Content: []types.ContentBlock{
+					&types.ContentBlockMemberText{Value: text},
+				},
+			},
+		},
+		StopReason: types.StopReasonEndTurn,
+	}
+}
 
 func TestConverse_GenerateContent_unary(t *testing.T) {
 	t.Parallel()
@@ -107,6 +123,56 @@ func TestConverse_GenerateContent_unary(t *testing.T) {
 	}
 	if got != 1 {
 		t.Fatalf("responses: %d", got)
+	}
+}
+
+func TestConverse_GenerateContent_unaryWithGuardrail(t *testing.T) {
+	t.Parallel()
+	api := &fakeAPI{converseOut: fakeTextOutput("ok")}
+	m, err := NewWithAPI("mid", api, WithGuardrail("guardrail-id", "DRAFT", types.GuardrailTraceEnabledFull))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{genai.NewContentFromText("hi", "user")},
+		Config:   &genai.GenerateContentConfig{},
+	}
+	for _, err := range m.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if api.converseIn == nil || api.converseIn.GuardrailConfig == nil {
+		t.Fatalf("missing guardrail config: %+v", api.converseIn)
+	}
+	cfg := api.converseIn.GuardrailConfig
+	if aws.ToString(cfg.GuardrailIdentifier) != "guardrail-id" ||
+		aws.ToString(cfg.GuardrailVersion) != "DRAFT" ||
+		cfg.Trace != types.GuardrailTraceEnabledFull {
+		t.Fatalf("guardrail config: %+v", cfg)
+	}
+}
+
+func TestNewWithAPI_WithGuardrailValidates(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		id      string
+		version string
+		trace   types.GuardrailTrace
+	}{
+		{"blank id", "", "1", types.GuardrailTraceEnabled},
+		{"blank version", "id", "", types.GuardrailTraceEnabled},
+		{"invalid trace", "id", "1", types.GuardrailTrace("bogus")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewWithAPI("mid", &fakeAPI{}, WithGuardrail(tt.id, tt.version, tt.trace))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
 	}
 }
 
@@ -159,6 +225,35 @@ func TestConverse_GenerateContent_stream(t *testing.T) {
 	}
 	if partial < 1 || final != 1 {
 		t.Fatalf("partial=%d final=%d", partial, final)
+	}
+}
+
+func TestConverse_GenerateContent_streamWithGuardrail(t *testing.T) {
+	t.Parallel()
+	ch := make(chan types.ConverseStreamOutput)
+	close(ch)
+	api := &fakeAPI{stream: &fakeStream{ch: ch}}
+	m, err := NewWithAPI("mid", api, WithGuardrail("guardrail-id", "1", types.GuardrailTraceEnabled))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{genai.NewContentFromText("hi", "user")},
+		Config:   &genai.GenerateContentConfig{},
+	}
+	for _, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if api.streamIn == nil || api.streamIn.GuardrailConfig == nil {
+		t.Fatalf("missing stream guardrail config: %+v", api.streamIn)
+	}
+	cfg := api.streamIn.GuardrailConfig
+	if aws.ToString(cfg.GuardrailIdentifier) != "guardrail-id" ||
+		aws.ToString(cfg.GuardrailVersion) != "1" ||
+		cfg.Trace != types.GuardrailTraceEnabled {
+		t.Fatalf("stream guardrail config: %+v", cfg)
 	}
 }
 

--- a/bedrock/modeloptions.go
+++ b/bedrock/modeloptions.go
@@ -1,5 +1,11 @@
 package bedrock
 
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+)
+
 // ModelOption configures a [Model].
 type ModelOption func(*Model)
 
@@ -9,4 +15,14 @@ type ModelOption func(*Model)
 // For more information on Bedrock Prompt Caching see https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html.
 func WithCacheSystemPrompt() ModelOption {
 	return func(m *Model) { m.cacheSystemPrompt = true }
+}
+
+// WithGuardrail attaches a preconfigured Bedrock guardrail to every request.
+func WithGuardrail(identifier, version string, trace types.GuardrailTrace) ModelOption {
+	return func(m *Model) {
+		m.guardrailConfigured = true
+		m.guardrailIdentifier = strings.TrimSpace(identifier)
+		m.guardrailVersion = strings.TrimSpace(version)
+		m.guardrailTrace = trace
+	}
 }

--- a/examples/bedrock-guardrails/README.md
+++ b/examples/bedrock-guardrails/README.md
@@ -65,9 +65,9 @@ To enable a pre-configured Bedrock guardrail in your applications:
 
 1. Create a guardrail in AWS Bedrock console
 2. Note its Identifier and Version
-3. Use the Bedrock Runtime API directly to pass guardrail configuration:
-   - The current ADK interface doesn't support request-side guardrail configuration
-   - See [Bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) for details
+3. Pass the guardrail to the Bedrock model with `bedrock.WithGuardrail(identifier, version, types.GuardrailTraceEnabled)`
+
+See [`examples/bedrock-request-guardrail`](../bedrock-request-guardrail) for a small request-side guardrail example.
 
 ## Example: Extracting Safety Ratings
 
@@ -89,7 +89,6 @@ for resp := range llm.GenerateContent(ctx, request, false) {
 
 - Bedrock guardrails require pre-provisioned AWS resources (guardrail ID and version)
 - ADK's generic `SafetySettings` cannot be automatically mapped to Bedrock guardrails
-- Guardrail metadata is available on response, but request-side configuration requires Bedrock-native APIs
 - Only function-based tools are supported; other tool types are ignored
 
 ## More Resources

--- a/examples/bedrock-guardrails/main.go
+++ b/examples/bedrock-guardrails/main.go
@@ -398,5 +398,5 @@ func main() {
 	fmt.Println("- FinishReason indicates if guardrails blocked the response")
 	fmt.Println("- Streaming accumulates guardrail metadata into final response")
 	fmt.Println("- Note: To use Bedrock guardrails, pre-configure a guardrail in AWS")
-	fmt.Println("  and pass its ID and version to the model via custom Bedrock APIs")
+	fmt.Println("  and pass its ID and version with bedrock.WithGuardrail")
 }

--- a/examples/bedrock-request-guardrail/Makefile
+++ b/examples/bedrock-request-guardrail/Makefile
@@ -1,0 +1,4 @@
+.PHONY: run
+
+run:
+	go run . $(PROMPT)

--- a/examples/bedrock-request-guardrail/README.md
+++ b/examples/bedrock-request-guardrail/README.md
@@ -1,0 +1,23 @@
+# bedrock-request-guardrail example
+
+This example attaches a preconfigured Bedrock guardrail to one Converse request with `bedrock.WithGuardrail`.
+
+## Prerequisites
+
+- `BEDROCK_MODEL_ID` set to a Bedrock model ID or inference profile ARN
+- `BEDROCK_GUARDRAIL_ID` set to a preconfigured Bedrock guardrail identifier
+- `BEDROCK_GUARDRAIL_VERSION` set to that guardrail version, for example `DRAFT`
+- AWS credentials configured via the default chain
+- AWS region configured (for example `AWS_REGION=us-east-1`)
+
+## Run
+
+```bash
+make -C examples/bedrock-request-guardrail run
+```
+
+Or pass a custom prompt:
+
+```bash
+make -C examples/bedrock-request-guardrail run PROMPT='Explain secrets management in one paragraph.'
+```

--- a/examples/bedrock-request-guardrail/main.go
+++ b/examples/bedrock-request-guardrail/main.go
@@ -1,0 +1,118 @@
+// Bedrock request guardrail example for adk-go: attaches a preconfigured
+// Bedrock guardrail to one Converse request.
+//
+// Set BEDROCK_MODEL_ID, BEDROCK_GUARDRAIL_ID, BEDROCK_GUARDRAIL_VERSION, and
+// authenticate with AWS using the default credential chain. Run:
+//
+//	go run ./examples/bedrock-request-guardrail
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"google.golang.org/adk/model"
+	"google.golang.org/genai"
+
+	"github.com/craigh33/adk-go-bedrock/bedrock"
+	"github.com/craigh33/adk-go-bedrock/examples/internal/exampletrace"
+)
+
+func main() {
+	ctx := context.Background()
+
+	var loadOpts []func(*config.LoadOptions) error
+	if r := strings.TrimSpace(os.Getenv("AWS_REGION")); r != "" {
+		loadOpts = append(loadOpts, config.WithRegion(r))
+	}
+	awsCfg, err := config.LoadDefaultConfig(ctx, loadOpts...)
+	if err != nil {
+		log.Fatalf("load AWS config (check credentials and AWS_PROFILE): %v", err)
+	}
+	if awsCfg.Region == "" {
+		log.Fatal("AWS region is unset: set AWS_REGION or add region to your ~/.aws/config profile")
+	}
+
+	modelID := strings.TrimSpace(os.Getenv("BEDROCK_MODEL_ID"))
+	if modelID == "" {
+		log.Println("BEDROCK_MODEL_ID not set, using default")
+		modelID = "eu.amazon.nova-2-lite-v1:0"
+	}
+	guardrailID := strings.TrimSpace(os.Getenv("BEDROCK_GUARDRAIL_ID"))
+	guardrailVersion := strings.TrimSpace(os.Getenv("BEDROCK_GUARDRAIL_VERSION"))
+	if guardrailID == "" || guardrailVersion == "" {
+		log.Fatal("set BEDROCK_GUARDRAIL_ID and BEDROCK_GUARDRAIL_VERSION")
+	}
+
+	prompt := strings.TrimSpace(os.Getenv("PROMPT"))
+	if prompt == "" {
+		prompt = "Explain why clear password policies matter in one short paragraph."
+	}
+	if len(os.Args) > 1 {
+		prompt = strings.TrimSpace(strings.Join(os.Args[1:], " "))
+	}
+
+	tp, shutdownTP, err := exampletrace.TracerProvider(ctx)
+	if err != nil {
+		log.Fatalf("tracer provider: %v", err)
+	}
+	defer func() { _ = shutdownTP(context.Background()) }()
+
+	br := bedrockruntime.NewFromConfig(awsCfg)
+	runtimeAPI := bedrock.NewRuntimeAPI(br, bedrock.WithTracerProvider(tp))
+	llm, err := bedrock.NewWithAPI(
+		modelID,
+		runtimeAPI,
+		bedrock.WithGuardrail(guardrailID, guardrailVersion, types.GuardrailTraceEnabled),
+	)
+	if err != nil {
+		log.Fatalf("create bedrock model: %v", err)
+	}
+
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{genai.NewContentFromText(prompt, genai.RoleUser)},
+		Config: &genai.GenerateContentConfig{
+			MaxOutputTokens: 512,
+		},
+	}
+
+	fmt.Printf("Model: %s\nGuardrail: %s:%s\nPrompt: %s\n\n", modelID, guardrailID, guardrailVersion, prompt)
+	for resp, err := range llm.GenerateContent(ctx, req, false) {
+		if err != nil {
+			log.Fatalf("generate: %v", err)
+		}
+		if resp == nil {
+			continue
+		}
+		if resp.Content != nil {
+			for _, part := range resp.Content.Parts {
+				if part.Text != "" {
+					fmt.Println(part.Text)
+				}
+			}
+		}
+		fmt.Printf("\nfinish_reason=%s\n", resp.FinishReason)
+		printGuardrailMetadata(resp)
+	}
+}
+
+func printGuardrailMetadata(resp *model.LLMResponse) {
+	if resp.CustomMetadata == nil {
+		fmt.Println("guardrail_trace=false")
+		return
+	}
+	if ratings, ok := resp.CustomMetadata["safety_ratings"].([]*genai.SafetyRating); ok {
+		for _, rating := range ratings {
+			fmt.Printf("safety_rating category=%s blocked=%t probability=%s\n",
+				rating.Category, rating.Blocked, rating.Probability)
+		}
+	}
+	_, hasTrace := resp.CustomMetadata["bedrock_guardrail_trace"]
+	fmt.Printf("guardrail_trace=%t\n", hasTrace)
+}

--- a/examples/bedrock-request-guardrail/main.go
+++ b/examples/bedrock-request-guardrail/main.go
@@ -72,6 +72,7 @@ func main() {
 		bedrock.WithGuardrail(guardrailID, guardrailVersion, types.GuardrailTraceEnabled),
 	)
 	if err != nil {
+		//nolint:gocritic // exitAfterDefer: example skips tracer shutdown on model setup failure
 		log.Fatalf("create bedrock model: %v", err)
 	}
 

--- a/tools/imagegenerator/tool.go
+++ b/tools/imagegenerator/tool.go
@@ -20,6 +20,7 @@ import (
 const DefaultCanvasModelID = "amazon.nova-canvas-v1:0"
 
 const (
+	imageToolName         = "generate_image"
 	defaultCanvasWidth    = 512
 	defaultCanvasHeight   = 512
 	defaultCanvasCfgScale = 8.0
@@ -89,7 +90,7 @@ func New(cfg Config) (tool.Tool, error) {
 }
 
 func (t *imageGenTool) Name() string {
-	return "generate_image"
+	return imageToolName
 }
 
 func (t *imageGenTool) Description() string {

--- a/tools/imagegenerator/tool_test.go
+++ b/tools/imagegenerator/tool_test.go
@@ -129,8 +129,8 @@ func TestNew_OK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if tl.Name() != "generate_image" {
-		t.Errorf("Name() = %q, want %q", tl.Name(), "generate_image")
+	if tl.Name() != imageToolName {
+		t.Errorf("Name() = %q, want %q", tl.Name(), imageToolName)
 	}
 	if tl.IsLongRunning() {
 		t.Error("IsLongRunning should be false")
@@ -149,7 +149,7 @@ func TestDeclaration(t *testing.T) {
 	if decl == nil {
 		t.Fatal("Declaration() returned nil")
 	}
-	if decl.Name != "generate_image" {
+	if decl.Name != imageToolName {
 		t.Errorf("declaration name = %q", decl.Name)
 	}
 	if decl.Parameters == nil || decl.Parameters.Properties["prompt"] == nil {
@@ -181,7 +181,7 @@ func TestProcessRequest_PacksDeclaration(t *testing.T) {
 	if len(req.Config.Tools[0].FunctionDeclarations) != 1 {
 		t.Fatal("expected one function declaration")
 	}
-	if req.Config.Tools[0].FunctionDeclarations[0].Name != "generate_image" {
+	if req.Config.Tools[0].FunctionDeclarations[0].Name != imageToolName {
 		t.Error("wrong declaration name")
 	}
 }


### PR DESCRIPTION
## Summary

Adds `bedrock.WithGuardrail(...)` for request-side Bedrock guardrails on Converse and ConverseStream. Includes `examples/bedrock-request-guardrail` and doc updates.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / enhancement (non-breaking change that adds behavior)
- [ ] Breaking change (fix or feature that could break existing callers)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Refactor / test / chore (no user-visible behavior change)

## Testing

- [x] `make test`
- [x] `make lint` (or equivalent local golangci-lint)
- [x] Example Created/Updated (`examples/bedrock-request-guardrail`)
- `go test ./... -count=1`

## Checklist

- [x] I ran **`pre-commit run --all-files`** (or equivalent local hooks).
- [x] My change follows existing patterns in this repository (naming, layout, error handling).
- [x] I updated docs when behavior, setup, or public API surface changed (if applicable).
- [x] I considered backwards compatibility for library consumers (if applicable).

## Related issues

None.
