### PR TITLE
feat(memoryService): #91: Add agent core package for agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ These runnable programs show how to wire `adk-go-bedrock` into ADK agents: chat 
 - [`examples/bedrock-guardrails`](examples/bedrock-guardrails): safety assessments, content filtering, and guardrail metadata handling.
 - [`examples/bedrock-request-guardrail`](examples/bedrock-request-guardrail): request-side Bedrock guardrail configuration via `ModelOption`.
 - [`examples/bedrock-system-instruction`](examples/bedrock-system-instruction): system instructions for role definition, output formatting, and behavioral control.
+- [`examples/bedrock-agentcore-memory`](examples/bedrock-agentcore-memory): long-term memory backed by Amazon Bedrock AgentCore Memory via [`memory/agentcore`](memory/agentcore) (see [Memory](#memory)).
 - [`examples/bedrock-web-ui`](examples/bedrock-web-ui): ADK local web UI launcher.
 
 All examples load AWS configuration with [`config.LoadDefaultConfig`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/config#LoadDefaultConfig) and require **`BEDROCK_MODEL_ID`** plus region configuration (`AWS_REGION` or profile region).
@@ -88,6 +89,34 @@ Run streaming example:
 ```bash
 make -C examples/bedrock-stream run
 ```
+
+## Memory
+
+The [`memory/agentcore`](memory/agentcore) package implements ADK's [`memory.Service`](https://pkg.go.dev/google.golang.org/adk/memory#Service) on top of **Amazon Bedrock AgentCore Memory**, the AWS analogue of ADK's Vertex AI MemoryBank adapter. Wire it into [`runner.Config.MemoryService`](https://pkg.go.dev/google.golang.org/adk/runner#Config) so agents can persist conversation events and recall long-term memory across sessions.
+
+- `AddSessionToMemory` writes each text-bearing session event to the Memory resource with `CreateEvent` (mapping the ADK user to an AgentCore actor and the session to an AgentCore session).
+- `SearchMemory` retrieves relevant records with `RetrieveMemoryRecords` and maps them back to `memory.Entry` values.
+
+```go
+memSvc, err := agentcore.New(ctx, &agentcore.Config{
+    MemoryID:  os.Getenv("AGENTCORE_MEMORY_ID"), // required
+    Region:    os.Getenv("AWS_REGION"),
+    Namespace: "/actors/{actorId}/facts",        // required to search; must match your strategy
+    TopK:      5,
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+r, err := runner.New(runner.Config{
+    AppName:        "my-app",
+    Agent:          agent,
+    SessionService: session.InMemoryService(),
+    MemoryService:  memSvc,
+})
+```
+
+The AgentCore Memory resource and its strategies must be provisioned out of band, and callers need IAM permission for `bedrock-agentcore:CreateEvent` and `bedrock-agentcore:RetrieveMemoryRecords`. **Long-term memory extraction is asynchronous**, so events written by `AddSessionToMemory` are not immediately returned by `SearchMemory`. A runnable program lives at [`examples/bedrock-agentcore-memory`](examples/bedrock-agentcore-memory).
 
 ## How it maps to Bedrock
 

--- a/examples/bedrock-agentcore-memory/Makefile
+++ b/examples/bedrock-agentcore-memory/Makefile
@@ -1,0 +1,4 @@
+.PHONY: run
+
+run:
+	go run . $(PROMPT)

--- a/examples/bedrock-agentcore-memory/README.md
+++ b/examples/bedrock-agentcore-memory/README.md
@@ -1,0 +1,42 @@
+# bedrock-agentcore-memory example
+
+This example wires the [`memory/agentcore`](../../memory/agentcore) service into an
+ADK runner. It writes a prior conversation to an Amazon Bedrock AgentCore Memory
+resource with `CreateEvent`, then runs an agent (with the `load_memory` /
+`preload_memory` tools) in a fresh session so it can recall that history via
+`RetrieveMemoryRecords`.
+
+## Prerequisites
+
+- A **provisioned AgentCore Memory resource** with a memory strategy. The strategy's
+  namespace template must match `AGENTCORE_NAMESPACE` below. Provisioning is done out
+  of band (AWS console, CLI, or the AgentCore control-plane API) — this example only
+  uses the data plane.
+- `BEDROCK_MODEL_ID` — a Bedrock model ID or inference profile ARN for the agent's LLM.
+- `AGENTCORE_MEMORY_ID` — the Memory resource ID.
+- `AGENTCORE_NAMESPACE` — the namespace prefix to search, e.g. `/actors/{actorId}/facts`.
+  The placeholders `{actorId}`, `{userId}` and `{appName}` are substituted per request
+  (by default `{actorId}` resolves to the ADK user ID).
+- `AGENTCORE_STRATEGY_ID` — *(optional)* memory strategy ID to filter retrieval.
+- AWS credentials via the default chain, and a region (`AWS_REGION` or your profile).
+- IAM permissions: `bedrock-agentcore:CreateEvent` and
+  `bedrock-agentcore:RetrieveMemoryRecords` (plus `bedrock:InvokeModel*` for the LLM).
+
+## Run
+
+```bash
+make -C examples/bedrock-agentcore-memory run
+```
+
+Or pass a custom prompt:
+
+```bash
+make -C examples/bedrock-agentcore-memory run PROMPT='Where did I eat ramen?'
+```
+
+## Note on asynchronous extraction
+
+Long-term memory extraction in AgentCore is **asynchronous**. Events written with
+`AddSessionToMemory` are not immediately returned by `SearchMemory`, so on a fresh run
+the agent may have nothing to recall. Re-run the recall query after extraction has had
+time to complete.

--- a/examples/bedrock-agentcore-memory/main.go
+++ b/examples/bedrock-agentcore-memory/main.go
@@ -1,0 +1,176 @@
+// Bedrock AgentCore Memory example for adk-go: persist a prior conversation to an
+// Amazon Bedrock AgentCore Memory resource and let an agent recall it in a new
+// session via the ADK load_memory / preload_memory tools.
+//
+// Authenticate with AWS using the default credential chain (environment variables,
+// shared config, SSO / AWS_PROFILE, EC2/ECS/Lambda role, etc.) and set:
+//
+//	BEDROCK_MODEL_ID        Bedrock model ID or inference profile ARN (LLM)
+//	AGENTCORE_MEMORY_ID     AgentCore Memory resource ID (required)
+//	AGENTCORE_NAMESPACE     namespace prefix to search, e.g. /actors/{actorId}/facts (required)
+//	AGENTCORE_STRATEGY_ID   memory strategy ID to filter retrieval (optional)
+//	AWS_REGION              region of the Memory resource (optional if set on profile)
+//
+// Long-term memory extraction in AgentCore is asynchronous, so a memory written in
+// this run is usually NOT searchable immediately — re-run the recall query after
+// extraction completes.
+//
+//	go run ./examples/bedrock-agentcore-memory
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/loadmemorytool"
+	"google.golang.org/adk/tool/preloadmemorytool"
+	"google.golang.org/genai"
+
+	"github.com/craigh33/adk-go-bedrock/bedrock"
+	"github.com/craigh33/adk-go-bedrock/memory/agentcore"
+)
+
+func main() {
+	ctx := context.Background()
+
+	region := strings.TrimSpace(os.Getenv("AWS_REGION"))
+
+	modelID := os.Getenv("BEDROCK_MODEL_ID")
+	if modelID == "" {
+		log.Println("BEDROCK_MODEL_ID is required (e.g. eu.amazon.nova-2-lite-v1:0) using default model")
+		modelID = "eu.amazon.nova-2-lite-v1:0"
+	}
+
+	memoryID := strings.TrimSpace(os.Getenv("AGENTCORE_MEMORY_ID"))
+	if memoryID == "" {
+		log.Fatal("AGENTCORE_MEMORY_ID is required (the AgentCore Memory resource ID)")
+	}
+	namespace := strings.TrimSpace(os.Getenv("AGENTCORE_NAMESPACE"))
+	if namespace == "" {
+		log.Fatal("AGENTCORE_NAMESPACE is required (e.g. /actors/{actorId}/facts); it must match your memory strategy")
+	}
+
+	llm, err := bedrock.New(ctx, modelID, &bedrock.Options{Region: region})
+	if err != nil {
+		log.Fatalf("bedrock model: %v", err)
+	}
+
+	memSvc, err := agentcore.New(ctx, &agentcore.Config{
+		MemoryID:   memoryID,
+		Region:     region,
+		Namespace:  namespace,
+		StrategyID: strings.TrimSpace(os.Getenv("AGENTCORE_STRATEGY_ID")),
+		TopK:       5,
+	})
+	if err != nil {
+		log.Fatalf("agentcore memory service: %v", err)
+	}
+
+	a, err := llmagent.New(llmagent.Config{
+		Name:        "memory_assistant",
+		Model:       llm,
+		Description: "Agent that can recall information from AgentCore Memory.",
+		Instruction: "You are a helpful assistant with access to long-term memory. " +
+			"Relevant memory may be preloaded automatically. If it is not enough, " +
+			"use the load_memory tool to search for more. Use what you recall to answer.",
+		Tools: []tool.Tool{
+			preloadmemorytool.New(),
+			loadmemorytool.New(),
+		},
+		GenerateContentConfig: &genai.GenerateContentConfig{MaxOutputTokens: 512},
+	})
+	if err != nil {
+		log.Fatalf("agent: %v", err)
+	}
+
+	userID, appName := "demo-user", "bedrock-agentcore-memory-example"
+	sessionService := session.InMemoryService()
+
+	// Seed a prior conversation and persist it to AgentCore Memory.
+	prior, err := seedPriorSession(ctx, sessionService, appName, userID)
+	if err != nil {
+		log.Fatalf("seed prior session: %v", err)
+	}
+	if err := memSvc.AddSessionToMemory(ctx, prior); err != nil {
+		log.Fatalf("add session to memory: %v", err)
+	}
+	fmt.Println("Wrote a prior conversation about a Tokyo trip to AgentCore Memory.")
+	fmt.Println("Note: long-term extraction is asynchronous — recall may be empty until it completes.")
+
+	// New session that should be able to recall the prior conversation.
+	resp, err := sessionService.Create(ctx, &session.CreateRequest{AppName: appName, UserID: userID})
+	if err != nil {
+		log.Fatalf("create session: %v", err)
+	}
+	current := resp.Session
+
+	r, err := runner.New(runner.Config{
+		AppName:        appName,
+		Agent:          a,
+		SessionService: sessionService,
+		MemoryService:  memSvc,
+	})
+	if err != nil {
+		log.Fatalf("runner: %v", err)
+	}
+
+	userMsg := "What do you remember about my trip to Tokyo?"
+	if len(os.Args) > 1 {
+		userMsg = os.Args[1]
+	}
+	printRecall(ctx, r, a.Name(), userID, current.ID(), userMsg)
+}
+
+// printRecall runs the agent once and prints its (non-partial) text response.
+func printRecall(ctx context.Context, r *runner.Runner, agentName, userID, sessionID, prompt string) {
+	fmt.Printf("\nUser  -> %s\nAgent -> ", prompt)
+	for ev, err := range r.Run(ctx, userID, sessionID, genai.NewContentFromText(prompt, genai.RoleUser), agent.RunConfig{}) {
+		if err != nil {
+			log.Fatalf("run: %v", err)
+		}
+		if ev.Author != agentName || ev.LLMResponse.Partial || ev.LLMResponse.Content == nil {
+			continue
+		}
+		for _, p := range ev.LLMResponse.Content.Parts {
+			if p.Text != "" {
+				fmt.Print(p.Text)
+			}
+		}
+	}
+	fmt.Println()
+}
+
+// seedPriorSession creates an in-memory session with a short conversation that is
+// later written to AgentCore Memory.
+func seedPriorSession(ctx context.Context, svc session.Service, appName, userID string) (session.Session, error) {
+	resp, err := svc.Create(ctx, &session.CreateRequest{AppName: appName, UserID: userID})
+	if err != nil {
+		return nil, err
+	}
+	s := resp.Session
+
+	turns := []struct{ author, content string }{
+		{"user", "I just got back from an amazing trip to Tokyo!"},
+		{"model", "That sounds wonderful! What were the highlights?"},
+		{"user", "I visited Senso-ji temple in Asakusa and had ramen in Shinjuku."},
+		{"model", "Great choices! Did you see any other sights?"},
+		{"user", "I went up Tokyo Skytree and saw Mount Fuji in the distance."},
+	}
+	for _, turn := range turns {
+		ev := session.NewEvent("prior-session")
+		ev.Author = turn.author
+		ev.Content = genai.NewContentFromText(turn.content, genai.Role(turn.author))
+		if err := svc.AppendEvent(ctx, s, ev); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24
+	github.com/aws/aws-sdk-go-v2/service/bedrockagentcore v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJa
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 h1:VTGy885W5DKBxWRUJbym9hytNaYzsyaPkCHGRRMAOhU=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30/go.mod h1:AS0HycUvJRFvTt613AYDOgO2jzw+00cVSMny8XB3yMY=
+github.com/aws/aws-sdk-go-v2/service/bedrockagentcore v1.32.0 h1:dMAQuMrwJYil5pBkVEHSd/6G3tfQgBUJjmZPQgUZKbQ=
+github.com/aws/aws-sdk-go-v2/service/bedrockagentcore v1.32.0/go.mod h1:vnZ1wWRlfwbFaTKqAUB6j7CMyQjvTEtsrdrsP2YcoEY=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.0 h1:b936xZEUR3j8UaPJFFwq/ZQpLdw4P/rhRn9UuK0pnr4=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.54.0/go.mod h1:8m0vIhh44Mmgb+x5o2WzTt0T5NKVtTBhO1j+t7AyvJI=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 h1:ZD2+BSw9vFsNlKYIasSNt3uDbjqqXIBcM13UJv/Lx2k=

--- a/memory/agentcore/agentcore.go
+++ b/memory/agentcore/agentcore.go
@@ -1,0 +1,224 @@
+// Package agentcore implements the ADK [memory.Service] interface using Amazon
+// Bedrock AgentCore Memory.
+//
+// It writes ADK session events to an AgentCore Memory resource with CreateEvent
+// and searches long-term memory with RetrieveMemoryRecords, so agents running on
+// Bedrock can persist and recall user-scoped memory across sessions through the
+// same [runner.Config.MemoryService] hook used for other providers.
+//
+// Long-term memory extraction in AgentCore is asynchronous: events written with
+// [Service.AddSessionToMemory] are not immediately returned by
+// [Service.SearchMemory]. Allow time for extraction to complete before expecting
+// freshly written events to be searchable.
+//
+// The AgentCore Memory resource (and its strategies/namespaces) must be
+// provisioned out of band. Callers need IAM permission for
+// bedrock-agentcore:CreateEvent and bedrock-agentcore:RetrieveMemoryRecords.
+package agentcore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcore"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcore/types"
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/session"
+)
+
+var _ memory.Service = (*Service)(nil)
+
+// defaultActorIDTemplate maps ADK identity to an AgentCore actor id. By default
+// the actor is the ADK user.
+const defaultActorIDTemplate = "{userId}"
+
+// API is the subset of Bedrock AgentCore operations used by this package. The
+// concrete [bedrockagentcore.Client] satisfies it directly, and tests can supply
+// a fake.
+type API interface {
+	CreateEvent(
+		ctx context.Context,
+		params *bedrockagentcore.CreateEventInput,
+		optFns ...func(*bedrockagentcore.Options),
+	) (*bedrockagentcore.CreateEventOutput, error)
+	RetrieveMemoryRecords(
+		ctx context.Context,
+		params *bedrockagentcore.RetrieveMemoryRecordsInput,
+		optFns ...func(*bedrockagentcore.Options),
+	) (*bedrockagentcore.RetrieveMemoryRecordsOutput, error)
+}
+
+// Config configures a [Service].
+type Config struct {
+	// MemoryID is the AgentCore Memory resource identifier. Required.
+	MemoryID string
+
+	// Region overrides the AWS region. When empty, the default
+	// [config.LoadDefaultConfig] resolution is used. Ignored by [NewWithAPI].
+	Region string
+
+	// Namespace is the namespace prefix searched by [Service.SearchMemory]. It
+	// supports the placeholders {actorId}, {userId} and {appName}, substituted
+	// per request. Either Namespace or NamespacePath must be set to search.
+	Namespace string
+
+	// NamespacePath, when set, is used instead of Namespace for hierarchical
+	// retrieval (all memory records under the same parent hierarchy). It supports
+	// the same placeholders as Namespace.
+	NamespacePath string
+
+	// StrategyID filters retrieval to a single memory strategy
+	// (SearchCriteria.MemoryStrategyId). Optional.
+	StrategyID string
+
+	// TopK sets the maximum number of top-scoring records used for semantic
+	// ranking (SearchCriteria.TopK). Optional; zero leaves it unset.
+	TopK int32
+
+	// MaxResults caps the number of records returned by a single search. Optional;
+	// zero uses the AgentCore default (20).
+	MaxResults int32
+
+	// MetadataFilters optionally narrows retrieval by memory metadata. Optional.
+	MetadataFilters []types.MemoryMetadataFilterExpression
+
+	// ActorIDTemplate maps ADK identity to an AgentCore actor id. It supports the
+	// placeholders {userId} and {appName}. Defaults to "{userId}".
+	ActorIDTemplate string
+}
+
+// Service implements [memory.Service] against an AgentCore Memory resource.
+type Service struct {
+	api API
+	cfg Config
+}
+
+// New creates a [Service] using the default AWS configuration chain and a new
+// [bedrockagentcore.Client]. cfg.MemoryID is required.
+func New(ctx context.Context, cfg *Config) (*Service, error) {
+	if cfg == nil {
+		return nil, errors.New("agentcore: config is required")
+	}
+	awsCfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("agentcore: load AWS config: %w", err)
+	}
+	if cfg.Region != "" {
+		awsCfg.Region = cfg.Region
+	}
+	return NewWithAPI(bedrockagentcore.NewFromConfig(awsCfg), cfg)
+}
+
+// NewWithAPI wires a [Service] to an existing AgentCore client (or fake). It is
+// the constructor used by tests and callers who build their own client.
+func NewWithAPI(api API, cfg *Config) (*Service, error) {
+	if api == nil {
+		return nil, errors.New("agentcore: API is required")
+	}
+	if cfg == nil {
+		return nil, errors.New("agentcore: config is required")
+	}
+	c := *cfg
+	if c.MemoryID == "" {
+		return nil, errors.New("agentcore: MemoryID is required")
+	}
+	if c.ActorIDTemplate == "" {
+		c.ActorIDTemplate = defaultActorIDTemplate
+	}
+	return &Service{api: api, cfg: c}, nil
+}
+
+// AddSessionToMemory writes the session's events to AgentCore Memory. It emits one
+// CreateEvent per text-bearing event, preserving each event's role and timestamp;
+// events without textual content are skipped. The event id is used as the
+// CreateEvent client token so repeated calls on a growing session are idempotent.
+//
+// AddSessionToMemory implements [memory.Service].
+func (s *Service) AddSessionToMemory(ctx context.Context, sess session.Session) error {
+	if sess == nil {
+		return errors.New("agentcore: session is nil")
+	}
+	actorID := resolveActor(s.cfg.ActorIDTemplate, sess.AppName(), sess.UserID())
+
+	for event := range sess.Events().All() {
+		text := textFromContent(event.LLMResponse.Content)
+		if text == "" {
+			continue
+		}
+		in := &bedrockagentcore.CreateEventInput{
+			MemoryId:       aws.String(s.cfg.MemoryID),
+			ActorId:        aws.String(actorID),
+			SessionId:      aws.String(sess.ID()),
+			EventTimestamp: aws.Time(eventTimestamp(event, sess)),
+			Payload: []types.PayloadType{
+				&types.PayloadTypeMemberConversational{
+					Value: types.Conversational{
+						Content: &types.ContentMemberText{Value: text},
+						Role:    toAgentCoreRole(event.LLMResponse.Content),
+					},
+				},
+			},
+			Metadata: eventMetadata(sess, event),
+		}
+		if event.ID != "" {
+			in.ClientToken = aws.String(event.ID)
+		}
+		if _, err := s.api.CreateEvent(ctx, in); err != nil {
+			return fmt.Errorf("agentcore: CreateEvent: %w", err)
+		}
+	}
+	return nil
+}
+
+// SearchMemory retrieves memory records relevant to req.Query and maps them to
+// [memory.Entry] values. The configured namespace (with {actorId}, {userId} and
+// {appName} substituted from the request) scopes the search; either
+// Config.Namespace or Config.NamespacePath must be set.
+//
+// SearchMemory implements [memory.Service].
+func (s *Service) SearchMemory(ctx context.Context, req *memory.SearchRequest) (*memory.SearchResponse, error) {
+	if req == nil {
+		return nil, errors.New("agentcore: search request is nil")
+	}
+	actorID := resolveActor(s.cfg.ActorIDTemplate, req.AppName, req.UserID)
+
+	in := &bedrockagentcore.RetrieveMemoryRecordsInput{
+		MemoryId: aws.String(s.cfg.MemoryID),
+		SearchCriteria: &types.SearchCriteria{
+			SearchQuery:     aws.String(req.Query),
+			MetadataFilters: s.cfg.MetadataFilters,
+		},
+	}
+	if s.cfg.StrategyID != "" {
+		in.SearchCriteria.MemoryStrategyId = aws.String(s.cfg.StrategyID)
+	}
+	if s.cfg.TopK > 0 {
+		in.SearchCriteria.TopK = aws.Int32(s.cfg.TopK)
+	}
+	if s.cfg.MaxResults > 0 {
+		in.MaxResults = aws.Int32(s.cfg.MaxResults)
+	}
+
+	switch {
+	case s.cfg.NamespacePath != "":
+		in.NamespacePath = aws.String(resolveNamespace(s.cfg.NamespacePath, req.AppName, req.UserID, actorID))
+	case s.cfg.Namespace != "":
+		in.Namespace = aws.String(resolveNamespace(s.cfg.Namespace, req.AppName, req.UserID, actorID))
+	default:
+		return nil, errors.New("agentcore: Namespace or NamespacePath is required to search")
+	}
+
+	out, err := s.api.RetrieveMemoryRecords(ctx, in)
+	if err != nil {
+		return nil, fmt.Errorf("agentcore: RetrieveMemoryRecords: %w", err)
+	}
+
+	res := &memory.SearchResponse{Memories: make([]memory.Entry, 0, len(out.MemoryRecordSummaries))}
+	for _, rec := range out.MemoryRecordSummaries {
+		res.Memories = append(res.Memories, recordToEntry(rec))
+	}
+	return res, nil
+}

--- a/memory/agentcore/agentcore_test.go
+++ b/memory/agentcore/agentcore_test.go
@@ -1,0 +1,403 @@
+package agentcore
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcore"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcore/types"
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+// fakeAPI is a test double for the AgentCore API.
+type fakeAPI struct {
+	createInputs []*bedrockagentcore.CreateEventInput
+	createErr    error
+
+	retrieveIn  *bedrockagentcore.RetrieveMemoryRecordsInput
+	retrieveOut *bedrockagentcore.RetrieveMemoryRecordsOutput
+	retrieveErr error
+}
+
+func (f *fakeAPI) CreateEvent(
+	_ context.Context,
+	in *bedrockagentcore.CreateEventInput,
+	_ ...func(*bedrockagentcore.Options),
+) (*bedrockagentcore.CreateEventOutput, error) {
+	f.createInputs = append(f.createInputs, in)
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	return &bedrockagentcore.CreateEventOutput{}, nil
+}
+
+func (f *fakeAPI) RetrieveMemoryRecords(
+	_ context.Context,
+	in *bedrockagentcore.RetrieveMemoryRecordsInput,
+	_ ...func(*bedrockagentcore.Options),
+) (*bedrockagentcore.RetrieveMemoryRecordsOutput, error) {
+	f.retrieveIn = in
+	if f.retrieveErr != nil {
+		return nil, f.retrieveErr
+	}
+	if f.retrieveOut != nil {
+		return f.retrieveOut, nil
+	}
+	return &bedrockagentcore.RetrieveMemoryRecordsOutput{}, nil
+}
+
+type seedEvent struct {
+	author string
+	role   string
+	text   string // "" => content-less event (should be skipped)
+}
+
+// newSession builds an in-memory session populated with the given events. Event
+// timestamps are set deterministically so assertions are stable.
+func newSession(t *testing.T, appName, userID string, events []seedEvent) session.Session {
+	t.Helper()
+	ctx := context.Background()
+	svc := session.InMemoryService()
+	resp, err := svc.Create(ctx, &session.CreateRequest{AppName: appName, UserID: userID})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	for i, e := range events {
+		ev := session.NewEvent("inv")
+		ev.Author = e.author
+		ev.Timestamp = base.Add(time.Duration(i) * time.Minute)
+		if e.text != "" {
+			ev.Content = genai.NewContentFromText(e.text, genai.Role(e.role))
+		}
+		if err := svc.AppendEvent(ctx, resp.Session, ev); err != nil {
+			t.Fatalf("append event: %v", err)
+		}
+	}
+	return resp.Session
+}
+
+func conversational(t *testing.T, in *bedrockagentcore.CreateEventInput) types.Conversational {
+	t.Helper()
+	if len(in.Payload) != 1 {
+		t.Fatalf("payload len = %d, want 1", len(in.Payload))
+	}
+	c, ok := in.Payload[0].(*types.PayloadTypeMemberConversational)
+	if !ok {
+		t.Fatalf("payload type = %T, want conversational", in.Payload[0])
+	}
+	return c.Value
+}
+
+func TestAddSessionToMemory(t *testing.T) {
+	t.Parallel()
+	api := &fakeAPI{}
+	svc, err := NewWithAPI(api, &Config{MemoryID: "mem-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sess := newSession(t, "app", "u1", []seedEvent{
+		{author: "user", role: genai.RoleUser, text: "hi"},
+		{author: "agent", role: genai.RoleModel, text: "hello"},
+		{author: "user", role: genai.RoleUser, text: ""}, // skipped
+	})
+
+	if err := svc.AddSessionToMemory(context.Background(), sess); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(api.createInputs) != 2 {
+		t.Fatalf("CreateEvent calls = %d, want 2 (content-less event skipped)", len(api.createInputs))
+	}
+
+	// Collect the source events to compare ids/order.
+	var srcIDs []string
+	for ev := range sess.Events().All() {
+		if textFromContent(ev.LLMResponse.Content) != "" {
+			srcIDs = append(srcIDs, ev.ID)
+		}
+	}
+
+	want := []struct {
+		text string
+		role types.Role
+	}{
+		{"hi", types.RoleUser},
+		{"hello", types.RoleAssistant},
+	}
+	for i, in := range api.createInputs {
+		assertCreateEvent(t, i, in, sess, srcIDs[i], want[i].text, want[i].role)
+	}
+}
+
+// assertCreateEvent checks a single CreateEvent input built by AddSessionToMemory.
+func assertCreateEvent(
+	t *testing.T,
+	i int,
+	in *bedrockagentcore.CreateEventInput,
+	sess session.Session,
+	wantToken, wantText string,
+	wantRole types.Role,
+) {
+	t.Helper()
+	if got := aws.ToString(in.MemoryId); got != "mem-1" {
+		t.Errorf("call %d MemoryId = %q, want mem-1", i, got)
+	}
+	if got := aws.ToString(in.ActorId); got != "u1" {
+		t.Errorf("call %d ActorId = %q, want u1 (default {userId})", i, got)
+	}
+	if got := aws.ToString(in.SessionId); got != sess.ID() {
+		t.Errorf("call %d SessionId = %q, want %q", i, got, sess.ID())
+	}
+	if in.EventTimestamp == nil {
+		t.Errorf("call %d EventTimestamp is nil", i)
+	}
+	if got := aws.ToString(in.ClientToken); got != wantToken {
+		t.Errorf("call %d ClientToken = %q, want event id %q", i, got, wantToken)
+	}
+	conv := conversational(t, in)
+	if conv.Role != wantRole {
+		t.Errorf("call %d role = %q, want %q", i, conv.Role, wantRole)
+	}
+	ct, ok := conv.Content.(*types.ContentMemberText)
+	if !ok {
+		t.Fatalf("call %d content type = %T, want text", i, conv.Content)
+	}
+	if ct.Value != wantText {
+		t.Errorf("call %d text = %q, want %q", i, ct.Value, wantText)
+	}
+	assertMetadata(t, in.Metadata, "app_name", "app")
+	assertMetadata(t, in.Metadata, "user_id", "u1")
+	assertMetadata(t, in.Metadata, "session_id", sess.ID())
+}
+
+func assertMetadata(t *testing.T, md map[string]types.MetadataValue, key, want string) {
+	t.Helper()
+	v, ok := md[key]
+	if !ok {
+		t.Errorf("metadata missing key %q", key)
+		return
+	}
+	sv, ok := v.(*types.MetadataValueMemberStringValue)
+	if !ok {
+		t.Errorf("metadata %q type = %T, want string value", key, v)
+		return
+	}
+	if sv.Value != want {
+		t.Errorf("metadata %q = %q, want %q", key, sv.Value, want)
+	}
+}
+
+func TestAddSessionToMemory_propagatesError(t *testing.T) {
+	t.Parallel()
+	api := &fakeAPI{createErr: errors.New("boom")}
+	svc, err := NewWithAPI(api, &Config{MemoryID: "mem-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := newSession(t, "app", "u1", []seedEvent{{author: "user", role: genai.RoleUser, text: "hi"}})
+	if err := svc.AddSessionToMemory(context.Background(), sess); err == nil {
+		t.Fatal("want error from CreateEvent, got nil")
+	}
+}
+
+func TestSearchMemory_buildsRequest(t *testing.T) {
+	t.Parallel()
+	api := &fakeAPI{}
+	svc, err := NewWithAPI(api, &Config{
+		MemoryID:   "mem-1",
+		Namespace:  "/actors/{actorId}/facts",
+		StrategyID: "strat-1",
+		TopK:       5,
+		MaxResults: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := svc.SearchMemory(context.Background(), &memory.SearchRequest{
+		Query:   "what is my name",
+		UserID:  "u1",
+		AppName: "app",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	in := api.retrieveIn
+	if in == nil {
+		t.Fatal("RetrieveMemoryRecords not called")
+	}
+	if got := aws.ToString(in.MemoryId); got != "mem-1" {
+		t.Errorf("MemoryId = %q, want mem-1", got)
+	}
+	if got := aws.ToString(in.Namespace); got != "/actors/u1/facts" {
+		t.Errorf("Namespace = %q, want /actors/u1/facts", got)
+	}
+	if in.NamespacePath != nil {
+		t.Errorf("NamespacePath = %v, want nil", aws.ToString(in.NamespacePath))
+	}
+	if got := aws.ToInt32(in.MaxResults); got != 10 {
+		t.Errorf("MaxResults = %d, want 10", got)
+	}
+	if in.SearchCriteria == nil {
+		t.Fatal("SearchCriteria is nil")
+	}
+	if got := aws.ToString(in.SearchCriteria.SearchQuery); got != "what is my name" {
+		t.Errorf("SearchQuery = %q", got)
+	}
+	if got := aws.ToString(in.SearchCriteria.MemoryStrategyId); got != "strat-1" {
+		t.Errorf("MemoryStrategyId = %q, want strat-1", got)
+	}
+	if got := aws.ToInt32(in.SearchCriteria.TopK); got != 5 {
+		t.Errorf("TopK = %d, want 5", got)
+	}
+}
+
+func TestSearchMemory_namespacePath(t *testing.T) {
+	t.Parallel()
+	api := &fakeAPI{}
+	svc, err := NewWithAPI(api, &Config{
+		MemoryID:      "mem-1",
+		NamespacePath: "/apps/{appName}/users/{userId}",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.SearchMemory(context.Background(), &memory.SearchRequest{
+		Query: "q", UserID: "u1", AppName: "app",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := aws.ToString(api.retrieveIn.NamespacePath); got != "/apps/app/users/u1" {
+		t.Errorf("NamespacePath = %q, want /apps/app/users/u1", got)
+	}
+	if api.retrieveIn.Namespace != nil {
+		t.Errorf("Namespace = %v, want nil", aws.ToString(api.retrieveIn.Namespace))
+	}
+}
+
+func TestSearchMemory_requiresNamespace(t *testing.T) {
+	t.Parallel()
+	api := &fakeAPI{}
+	svc, err := NewWithAPI(api, &Config{MemoryID: "mem-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.SearchMemory(context.Background(), &memory.SearchRequest{Query: "q", UserID: "u1"}); err == nil {
+		t.Fatal("want error when no namespace configured, got nil")
+	}
+}
+
+func TestSearchMemory_mapsRecords(t *testing.T) {
+	t.Parallel()
+	created := time.Date(2026, 5, 6, 7, 8, 9, 0, time.UTC)
+	api := &fakeAPI{
+		retrieveOut: &bedrockagentcore.RetrieveMemoryRecordsOutput{
+			MemoryRecordSummaries: []types.MemoryRecordSummary{
+				{
+					MemoryRecordId:   aws.String("rec-1"),
+					Content:          &types.MemoryContentMemberText{Value: "user lives in Berlin"},
+					CreatedAt:        aws.Time(created),
+					MemoryStrategyId: aws.String("strat-1"),
+					Namespaces:       []string{"/actors/u1/facts"},
+					Score:            aws.Float64(0.87),
+				},
+			},
+		},
+	}
+	svc, err := NewWithAPI(api, &Config{MemoryID: "mem-1", Namespace: "/actors/{actorId}/facts"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := svc.SearchMemory(context.Background(), &memory.SearchRequest{Query: "where", UserID: "u1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Memories) != 1 {
+		t.Fatalf("memories = %d, want 1", len(res.Memories))
+	}
+	e := res.Memories[0]
+	if e.ID != "rec-1" {
+		t.Errorf("ID = %q, want rec-1", e.ID)
+	}
+	if e.Content == nil || len(e.Content.Parts) == 0 || e.Content.Parts[0].Text != "user lives in Berlin" {
+		t.Errorf("Content = %+v, want text 'user lives in Berlin'", e.Content)
+	}
+	if !e.Timestamp.Equal(created) {
+		t.Errorf("Timestamp = %v, want %v", e.Timestamp, created)
+	}
+	if got := e.CustomMetadata["score"]; got != 0.87 {
+		t.Errorf("score = %v, want 0.87", got)
+	}
+	if got := e.CustomMetadata["memory_strategy_id"]; got != "strat-1" {
+		t.Errorf("memory_strategy_id = %v, want strat-1", got)
+	}
+}
+
+func TestNewWithAPI_validation(t *testing.T) {
+	t.Parallel()
+	if _, err := NewWithAPI(nil, &Config{MemoryID: "m"}); err == nil {
+		t.Error("want error for nil api")
+	}
+	if _, err := NewWithAPI(&fakeAPI{}, nil); err == nil {
+		t.Error("want error for nil config")
+	}
+	if _, err := NewWithAPI(&fakeAPI{}, &Config{}); err == nil {
+		t.Error("want error for empty MemoryID")
+	}
+	svc, err := NewWithAPI(&fakeAPI{}, &Config{MemoryID: "m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if svc.cfg.ActorIDTemplate != defaultActorIDTemplate {
+		t.Errorf("ActorIDTemplate default = %q, want %q", svc.cfg.ActorIDTemplate, defaultActorIDTemplate)
+	}
+}
+
+func TestResolveActor(t *testing.T) {
+	t.Parallel()
+	if got := resolveActor("{userId}", "app", "u1"); got != "u1" {
+		t.Errorf("got %q, want u1", got)
+	}
+	if got := resolveActor("{appName}#{userId}", "app", "u1"); got != "app#u1" {
+		t.Errorf("got %q, want app#u1", got)
+	}
+}
+
+func TestToAgentCoreRole(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		role string
+		want types.Role
+	}{
+		{genai.RoleUser, types.RoleUser},
+		{genai.RoleModel, types.RoleAssistant},
+		{"function", types.RoleOther},
+	}
+	for _, c := range cases {
+		if got := toAgentCoreRole(genai.NewContentFromText("x", genai.Role(c.role))); got != c.want {
+			t.Errorf("role %q -> %q, want %q", c.role, got, c.want)
+		}
+	}
+	if got := toAgentCoreRole(nil); got != types.RoleOther {
+		t.Errorf("nil content -> %q, want OTHER", got)
+	}
+}
+
+func TestTextFromContent(t *testing.T) {
+	t.Parallel()
+	if got := textFromContent(nil); got != "" {
+		t.Errorf("nil -> %q, want empty", got)
+	}
+	multi := &genai.Content{Parts: []*genai.Part{{Text: "a"}, {Text: ""}, {Text: "b"}}}
+	if got := textFromContent(multi); got != "a\nb" {
+		t.Errorf("multi -> %q, want 'a\\nb'", got)
+	}
+}

--- a/memory/agentcore/mapping.go
+++ b/memory/agentcore/mapping.go
@@ -1,0 +1,130 @@
+package agentcore
+
+import (
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcore/types"
+	"google.golang.org/adk/memory"
+	"google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+// resolveActor maps ADK identity to an AgentCore actor id using template. It
+// supports the {userId} and {appName} placeholders.
+func resolveActor(template, appName, userID string) string {
+	return strings.NewReplacer(
+		"{userId}", userID,
+		"{appName}", appName,
+	).Replace(template)
+}
+
+// resolveNamespace substitutes the {actorId}, {userId} and {appName} placeholders
+// in an AgentCore namespace (or namespace path).
+func resolveNamespace(template, appName, userID, actorID string) string {
+	return strings.NewReplacer(
+		"{actorId}", actorID,
+		"{userId}", userID,
+		"{appName}", appName,
+	).Replace(template)
+}
+
+// textFromContent concatenates the text of all textual parts of c, separating
+// non-empty parts with a newline. It returns "" when c is nil or carries no text
+// (for example a bare function call/response), signalling the event should be
+// skipped.
+func textFromContent(c *genai.Content) string {
+	if c == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, p := range c.Parts {
+		if p == nil || p.Text == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(p.Text)
+	}
+	return b.String()
+}
+
+// toAgentCoreRole maps a genai content role to an AgentCore conversational role.
+func toAgentCoreRole(c *genai.Content) types.Role {
+	if c == nil {
+		return types.RoleOther
+	}
+	switch c.Role {
+	case genai.RoleUser:
+		return types.RoleUser
+	case genai.RoleModel:
+		return types.RoleAssistant
+	default:
+		return types.RoleOther
+	}
+}
+
+// eventTimestamp returns the timestamp to record for event, falling back to the
+// session's last-update time and finally the current time. AgentCore requires a
+// non-nil EventTimestamp.
+func eventTimestamp(event *session.Event, sess session.Session) time.Time {
+	if !event.Timestamp.IsZero() {
+		return event.Timestamp
+	}
+	if t := sess.LastUpdateTime(); !t.IsZero() {
+		return t
+	}
+	return time.Now()
+}
+
+// eventMetadata attaches ADK identifiers to an AgentCore event for traceability.
+func eventMetadata(sess session.Session, event *session.Event) map[string]types.MetadataValue {
+	md := map[string]types.MetadataValue{
+		"app_name":   &types.MetadataValueMemberStringValue{Value: sess.AppName()},
+		"user_id":    &types.MetadataValueMemberStringValue{Value: sess.UserID()},
+		"session_id": &types.MetadataValueMemberStringValue{Value: sess.ID()},
+	}
+	if event.Author != "" {
+		md["author"] = &types.MetadataValueMemberStringValue{Value: event.Author}
+	}
+	if event.ID != "" {
+		md["event_id"] = &types.MetadataValueMemberStringValue{Value: event.ID}
+	}
+	return md
+}
+
+// recordToEntry converts an AgentCore memory record summary to an ADK memory
+// entry. The record's relevance score, strategy and namespaces are preserved as
+// custom metadata.
+func recordToEntry(rec types.MemoryRecordSummary) memory.Entry {
+	entry := memory.Entry{
+		ID:        aws.ToString(rec.MemoryRecordId),
+		Content:   genai.NewContentFromText(memoryContentText(rec.Content), genai.RoleUser),
+		Timestamp: aws.ToTime(rec.CreatedAt),
+	}
+
+	meta := map[string]any{}
+	if rec.Score != nil {
+		meta["score"] = *rec.Score
+	}
+	if rec.MemoryStrategyId != nil {
+		meta["memory_strategy_id"] = *rec.MemoryStrategyId
+	}
+	if len(rec.Namespaces) > 0 {
+		meta["namespaces"] = rec.Namespaces
+	}
+	if len(meta) > 0 {
+		entry.CustomMetadata = meta
+	}
+	return entry
+}
+
+// memoryContentText extracts the text from an AgentCore memory content union.
+func memoryContentText(c types.MemoryContent) string {
+	if t, ok := c.(*types.MemoryContentMemberText); ok {
+		return t.Value
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Implements an ADK [`memory.Service`](https://pkg.go.dev/google.golang.org/adk/memory#Service) backed by **Amazon Bedrock AgentCore Memory** (#91) — the AWS analogue of ADK's Vertex AI MemoryBank adapter. Agents running on Bedrock can now persist conversation events and recall long-term, user-scoped memory across sessions by wiring the service into `runner.Config.MemoryService`, without standing up a custom store.

New package `memory/agentcore`:

- **`AddSessionToMemory`** writes each text-bearing session event to the Memory resource with `CreateEvent` — one event per ADK event, using the event ID as the `clientToken` so repeated calls on a growing session are idempotent. ADK `UserID` maps to the AgentCore `actorId` (configurable via `ActorIDTemplate`, default `{userId}`), `SessionID` to the AgentCore `sessionId`, and `AppName`/`UserID`/`SessionID`/author/event-id are attached as event metadata.
- **`SearchMemory`** queries `RetrieveMemoryRecords` (namespace or namespace-path with `{actorId}`/`{userId}`/`{appName}` substitution, optional strategy ID, TopK, MaxResults, and metadata filters) and maps each record back to a `memory.Entry` (id, content text, timestamp, plus score/strategy/namespaces as custom metadata).
- Mirrors existing repo conventions: a minimal injectable `API` interface, a `New` (loads the AWS config chain + region override) / `NewWithAPI` (tests and custom clients) constructor split, a package doc comment, and `%w` error wrapping.

Also adds the `github.com/aws/aws-sdk-go-v2/service/bedrockagentcore` dependency and updates docs.

**Notes for users** (documented in the README, example README, and package doc): the AgentCore Memory resource and its strategies must be provisioned out of band; callers need `bedrock-agentcore:CreateEvent` and `bedrock-agentcore:RetrieveMemoryRecords` IAM permissions; and **long-term memory extraction is asynchronous**, so freshly written events are not immediately searchable.

## Type of change

- [x] New feature / enhancement (non-breaking change that adds behavior)

This is a new, separate optional package — no existing public API changes.

## Testing

- [x] `make test` — full suite green, including 10 new tests in `memory/agentcore`
- [x] `make lint` (golangci-lint) — `0 issues` repo-wide; `gofmt` clean
- [x] Example Created/Updated — `examples/bedrock-agentcore-memory`: seeds a prior conversation, calls `AddSessionToMemory`, then recalls it in a fresh session via the `load_memory` / `preload_memory` tools

Unit tests use a fake AgentCore client and cover request construction, event→payload mapping, record→entry mapping, actor/namespace template resolution, and constructor validation.

## Checklist

- [ ] I ran **`pre-commit run --all-files`** (not run in this environment; `make test` + `make lint` + `gofmt` verified instead)
- [x] My change follows existing patterns in this repository (naming, layout, error handling).
- [x] I updated docs when behavior, setup, or public API surface changed (README Memory section, example READMEs, package doc).
- [x] I considered backwards compatibility for library consumers (new optional package; AgentCore SDK is only compiled when imported).

## Related issues

Fixes #91
