### PR TITLE
feat(artifact/s3): add PresignLoad for pre-signed GET URLs

### DIFF
--- a/artifact/s3/README.md
+++ b/artifact/s3/README.md
@@ -87,9 +87,8 @@ resp, err := svc.PresignLoad(ctx, &s3artifact.PresignLoadRequest{
 `Config.Presigner` is opt-in: services that do not set it are unaffected and
 `PresignLoad` returns an error if called without one.
 
-No additional IAM actions are needed beyond `s3:GetObject` (already required for
-`Load`). The credentials embedded in the signed URL belong to the signer at
-signing time.
+No additional S3 actions are needed beyond `s3:GetObject` (already required for `Load`), but if objects are encrypted with SSE-KMS you may also need `kms:Decrypt` on the KMS key.
+The credentials embedded in the signed URL belong to the signer at signing time.
 
 ## Limitations
 

--- a/artifact/s3/README.md
+++ b/artifact/s3/README.md
@@ -59,6 +59,38 @@ S3 bucket versioning is not used and is not required.
 - **Explicit version** (`SaveRequest.Version > 0`): written at exactly that version. Writing to an already-existing version returns an error wrapping `fs.ErrExist` — versions are immutable once written.
 - Concurrent saves of the same artifact with auto-increment can race. Use external coordination if strictly monotonic versions are required.
 
+## Pre-signed URLs
+
+`PresignLoad` generates a short-lived S3 GET URL so callers can hand a
+direct-download link to a client without streaming bytes through the
+application layer.
+
+```go
+pc := s3.NewPresignClient(s3Client)
+
+svc, err := s3artifact.NewService(s3Client, s3artifact.Config{
+    Bucket:     "my-artifact-bucket",
+    Presigner:  s3artifact.PresignClientAdapter{Client: pc},
+    PresignTTL: 15 * time.Minute, // default; override per-request with PresignLoadRequest.TTL
+})
+
+resp, err := svc.PresignLoad(ctx, &s3artifact.PresignLoadRequest{
+    AppName: "my-app", UserID: "u1", SessionID: "s1",
+    FileName: "report.pdf",   // Version 0 = latest
+    TTL:      time.Hour,      // overrides PresignTTL for this request
+})
+// resp.URL   — signed https://… URL
+// resp.Version — resolved version
+// resp.Expires — approximate expiry time
+```
+
+`Config.Presigner` is opt-in: services that do not set it are unaffected and
+`PresignLoad` returns an error if called without one.
+
+No additional IAM actions are needed beyond `s3:GetObject` (already required for
+`Load`). The credentials embedded in the signed URL belong to the signer at
+signing time.
+
 ## Limitations
 
 - Concurrent auto-increment saves of the same artifact are not atomic; two concurrent saves may compute the same next version and one will silently win.

--- a/artifact/s3/presign.go
+++ b/artifact/s3/presign.go
@@ -1,0 +1,115 @@
+package s3artifact
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+const defaultPresignTTL = 15 * time.Minute
+
+// Presigner generates pre-signed S3 GET URLs. Use [PresignClientAdapter] to
+// wrap *s3.PresignClient from your configured AWS SDK.
+type Presigner interface {
+	PresignGetObject(ctx context.Context, bucket, key string, ttl time.Duration) (url string, err error)
+}
+
+// PresignClientAdapter adapts *s3.PresignClient to [Presigner].
+//
+//	pc := s3.NewPresignClient(s3Client)
+//	svc, _ := s3artifact.NewService(s3Client, s3artifact.Config{
+//	    Bucket:    "my-bucket",
+//	    Presigner: s3artifact.PresignClientAdapter{Client: pc},
+//	})
+type PresignClientAdapter struct {
+	Client *s3.PresignClient
+}
+
+func (a PresignClientAdapter) PresignGetObject(
+	ctx context.Context,
+	bucket, key string,
+	ttl time.Duration,
+) (string, error) {
+	req, err := a.Client.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}, func(opts *s3.PresignOptions) {
+		opts.Expires = ttl
+	})
+	if err != nil {
+		return "", err
+	}
+	return req.URL, nil
+}
+
+// PresignLoadRequest is the input to [Service.PresignLoad].
+type PresignLoadRequest struct {
+	AppName   string
+	UserID    string
+	SessionID string
+	FileName  string
+	// Version to sign a URL for. 0 resolves to the latest version.
+	Version int64
+	// TTL overrides [Config.PresignTTL] for this request.
+	// 0 falls back to Config.PresignTTL, then to 15 minutes.
+	TTL time.Duration
+}
+
+func (r *PresignLoadRequest) validate() error {
+	if r.AppName == "" {
+		return errors.New("AppName is required")
+	}
+	if r.UserID == "" {
+		return errors.New("UserID is required")
+	}
+	if r.FileName == "" {
+		return errors.New("FileName is required")
+	}
+	return nil
+}
+
+// PresignLoadResponse is the output of [Service.PresignLoad].
+type PresignLoadResponse struct {
+	// URL is the pre-signed GET URL for the artifact.
+	URL string
+	// Version is the resolved version the URL points at.
+	Version int64
+	// Expires is the approximate wall-clock time the URL becomes invalid.
+	Expires time.Time
+}
+
+// PresignLoad returns a pre-signed GET URL for an artifact. Version 0
+// resolves to the latest version. Requires [Config.Presigner] to be set.
+func (s *Service) PresignLoad(ctx context.Context, req *PresignLoadRequest) (*PresignLoadResponse, error) {
+	if s.cfg.Presigner == nil {
+		return nil, errors.New("s3artifact: Presigner not configured in Config")
+	}
+	if err := req.validate(); err != nil {
+		return nil, fmt.Errorf("request validation failed: %w", err)
+	}
+	version, err := s.resolveVersion(ctx, req.AppName, req.UserID, req.SessionID, req.FileName, req.Version)
+	if err != nil {
+		return nil, err
+	}
+	ttl := req.TTL
+	if ttl == 0 {
+		ttl = s.cfg.PresignTTL
+	}
+	if ttl == 0 {
+		ttl = defaultPresignTTL
+	}
+	key := s.objectKey(req.AppName, req.UserID, req.SessionID, req.FileName, version)
+	url, err := s.cfg.Presigner.PresignGetObject(ctx, s.cfg.Bucket, key, ttl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to presign artifact URL: %w", err)
+	}
+	return &PresignLoadResponse{
+		URL:     url,
+		Version: version,
+		Expires: time.Now().Add(ttl),
+	}, nil
+}

--- a/artifact/s3/presign.go
+++ b/artifact/s3/presign.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -34,6 +35,9 @@ func (a PresignClientAdapter) PresignGetObject(
 	bucket, key string,
 	ttl time.Duration,
 ) (string, error) {
+	if a.Client == nil {
+		return "", errors.New("s3artifact: PresignClientAdapter.Client is nil")
+	}
 	req, err := a.Client.PresignGetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -69,6 +73,15 @@ func (r *PresignLoadRequest) validate() error {
 	if r.FileName == "" {
 		return errors.New("FileName is required")
 	}
+	if r.SessionID == "" {
+		return errors.New("SessionID is required")
+	}
+	if r.Version < 0 {
+		return errors.New("version must be non-negative")
+	}
+	if r.TTL < 0 {
+		return errors.New("TTL must be non-negative")
+	}
 	return nil
 }
 
@@ -91,22 +104,42 @@ func (s *Service) PresignLoad(ctx context.Context, req *PresignLoadRequest) (*Pr
 	if err := req.validate(); err != nil {
 		return nil, fmt.Errorf("request validation failed: %w", err)
 	}
+
 	version, err := s.resolveVersion(ctx, req.AppName, req.UserID, req.SessionID, req.FileName, req.Version)
 	if err != nil {
 		return nil, err
 	}
+
+	// resolveVersion returns an explicit version as-is without an S3 probe.
+	// Verify the object exists so callers get fs.ErrNotExist rather than a
+	// signed URL that returns 404 on use.
+	if req.Version != 0 {
+		key := s.objectKey(req.AppName, req.UserID, req.SessionID, req.FileName, version)
+		if _, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
+			Bucket: aws.String(s.cfg.Bucket),
+			Key:    aws.String(key),
+		}); err != nil {
+			if isNotFound(err) {
+				return nil, fmt.Errorf("artifact %q version %d not found: %w", req.FileName, version, fs.ErrNotExist)
+			}
+			return nil, fmt.Errorf("could not verify artifact %q version %d: %w", req.FileName, version, err)
+		}
+	}
+
 	ttl := req.TTL
-	if ttl == 0 {
+	if ttl <= 0 {
 		ttl = s.cfg.PresignTTL
 	}
-	if ttl == 0 {
+	if ttl <= 0 {
 		ttl = defaultPresignTTL
 	}
+
 	key := s.objectKey(req.AppName, req.UserID, req.SessionID, req.FileName, version)
 	url, err := s.cfg.Presigner.PresignGetObject(ctx, s.cfg.Bucket, key, ttl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to presign artifact URL: %w", err)
 	}
+
 	return &PresignLoadResponse{
 		URL:     url,
 		Version: version,

--- a/artifact/s3/presign.go
+++ b/artifact/s3/presign.go
@@ -137,7 +137,7 @@ func (s *Service) PresignLoad(ctx context.Context, req *PresignLoadRequest) (*Pr
 	key := s.objectKey(req.AppName, req.UserID, req.SessionID, req.FileName, version)
 	url, err := s.cfg.Presigner.PresignGetObject(ctx, s.cfg.Bucket, key, ttl)
 	if err != nil {
-		return nil, fmt.Errorf("failed to presign artifact URL: %w", err)
+		return nil, fmt.Errorf("failed to presign s3://%s/%s: %w", s.cfg.Bucket, key, err)
 	}
 
 	return &PresignLoadResponse{

--- a/artifact/s3/presign_test.go
+++ b/artifact/s3/presign_test.go
@@ -2,6 +2,8 @@ package s3artifact
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"strings"
 	"testing"
 	"time"
@@ -158,6 +160,111 @@ func TestPresignLoadErrorsWhenArtifactNotFound(t *testing.T) {
 	})
 	if !isFSNotExist(err) {
 		t.Fatalf("want fs.ErrNotExist, got %v", err)
+	}
+}
+
+func TestPresignLoadNilClientErrors(t *testing.T) {
+	adapter := PresignClientAdapter{Client: nil}
+	_, err := adapter.PresignGetObject(context.Background(), "b", "k", time.Minute)
+	if err == nil {
+		t.Fatal("want error for nil Client")
+	}
+}
+
+func TestPresignLoadMissingSessionIDErrors(t *testing.T) {
+	presigner := &fakePresigner{}
+	svc := newTestService(t, newFakeS3(), Config{Bucket: "b", Presigner: presigner})
+	_, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", FileName: "report.txt",
+		// SessionID deliberately omitted — session-scoped artifact
+	})
+	if err == nil {
+		t.Fatal("want error when SessionID is empty for session-scoped artifact")
+	}
+}
+
+func TestPresignLoadNegativeVersionErrors(t *testing.T) {
+	presigner := &fakePresigner{}
+	svc := newTestService(t, newFakeS3(), Config{Bucket: "b", Presigner: presigner})
+	_, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt",
+		Version: -1,
+	})
+	if err == nil {
+		t.Fatal("want error for negative Version")
+	}
+}
+
+func TestPresignLoadNegativeTTLErrors(t *testing.T) {
+	presigner := &fakePresigner{}
+	svc := newTestService(t, newFakeS3(), Config{Bucket: "b", Presigner: presigner})
+	saveText(t, svc, "report.txt", "x")
+	_, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt",
+		TTL: -time.Minute,
+	})
+	if err == nil {
+		t.Fatal("want error for negative TTL")
+	}
+}
+
+func TestPresignLoadNegativeConfigTTLFallsToDefault(t *testing.T) {
+	fake := newFakeS3()
+	presigner := &fakePresigner{}
+	svc := newTestService(t, fake, Config{Bucket: "b", Presigner: presigner, PresignTTL: -time.Hour})
+	saveText(t, svc, "report.txt", "x")
+
+	if _, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt",
+	}); err != nil {
+		t.Fatalf("PresignLoad: %v", err)
+	}
+	if got := presigner.calls[0].ttl; got != defaultPresignTTL {
+		t.Fatalf("ttl = %v, want %v (should fall back from negative config TTL to default)", got, defaultPresignTTL)
+	}
+}
+
+func TestPresignLoadSpecificVersionMissingErrors(t *testing.T) {
+	fake := newFakeS3()
+	presigner := &fakePresigner{}
+	svc := newTestService(t, fake, Config{Bucket: "b", Presigner: presigner})
+	saveText(t, svc, "report.txt", "v1")
+
+	_, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt",
+		Version: 99,
+	})
+	if !isFSNotExist(err) {
+		t.Fatalf("want fs.ErrNotExist for non-existent version, got %v", err)
+	}
+}
+
+func TestPresignLoadUserScopedKeyUsesUserNamespace(t *testing.T) {
+	fake := newFakeS3()
+	presigner := &fakePresigner{}
+	svc := newTestService(t, fake, Config{Bucket: "b", Presigner: presigner})
+	saveText(t, svc, "user:profile.txt", "data")
+
+	resp, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1",
+		FileName: "user:profile.txt",
+	})
+	if err != nil {
+		t.Fatalf("PresignLoad user-scoped: %v", err)
+	}
+	if !strings.Contains(resp.URL, "/user/") {
+		t.Fatalf("URL = %q, want user-scoped key path", resp.URL)
+	}
+}
+
+func TestPresignLoadErrorsWhenArtifactNotFoundExplicitVersion(t *testing.T) {
+	presigner := &fakePresigner{}
+	svc := newTestService(t, newFakeS3(), Config{Bucket: "b", Presigner: presigner})
+	_, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "nope.txt", Version: 1,
+	})
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("want fs.ErrNotExist for missing specific version, got %v", err)
 	}
 }
 

--- a/artifact/s3/presign_test.go
+++ b/artifact/s3/presign_test.go
@@ -1,0 +1,178 @@
+package s3artifact
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakePresigner records calls and returns a deterministic URL.
+type fakePresigner struct {
+	calls []fakePresignCall
+	err   error
+}
+
+type fakePresignCall struct {
+	bucket string
+	key    string
+	ttl    time.Duration
+}
+
+func (f *fakePresigner) PresignGetObject(_ context.Context, bucket, key string, ttl time.Duration) (string, error) {
+	f.calls = append(f.calls, fakePresignCall{bucket: bucket, key: key, ttl: ttl})
+	if f.err != nil {
+		return "", f.err
+	}
+	return "https://s3.example.com/" + bucket + "/" + key + "?X-Amz-Signature=fake", nil
+}
+
+func TestPresignLoadReturnsURL(t *testing.T) {
+	fake := newFakeS3()
+	presigner := &fakePresigner{}
+	svc := newTestService(t, fake, Config{Bucket: "b", Presigner: presigner})
+	saveText(t, svc, "report.txt", "hello")
+
+	resp, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt",
+	})
+	if err != nil {
+		t.Fatalf("PresignLoad: %v", err)
+	}
+	if resp.Version != 1 {
+		t.Fatalf("Version = %d, want 1", resp.Version)
+	}
+	if !strings.Contains(resp.URL, "app/u1/s1/report.txt/1") {
+		t.Fatalf("URL = %q, want to contain object key", resp.URL)
+	}
+	if resp.Expires.IsZero() {
+		t.Fatal("Expires not set")
+	}
+}
+
+func TestPresignLoadResolvesLatestVersion(t *testing.T) {
+	fake := newFakeS3()
+	presigner := &fakePresigner{}
+	svc := newTestService(t, fake, Config{Bucket: "b", Presigner: presigner})
+	saveText(t, svc, "report.txt", "v1")
+	saveText(t, svc, "report.txt", "v2")
+
+	resp, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt",
+	})
+	if err != nil {
+		t.Fatalf("PresignLoad: %v", err)
+	}
+	if resp.Version != 2 {
+		t.Fatalf("Version = %d, want 2", resp.Version)
+	}
+	if !strings.HasSuffix(presigner.calls[0].key, "/2") {
+		t.Fatalf("key = %q, want to end in /2", presigner.calls[0].key)
+	}
+}
+
+func TestPresignLoadSpecificVersion(t *testing.T) {
+	fake := newFakeS3()
+	presigner := &fakePresigner{}
+	svc := newTestService(t, fake, Config{Bucket: "b", Presigner: presigner})
+	saveText(t, svc, "report.txt", "v1")
+	saveText(t, svc, "report.txt", "v2")
+
+	resp, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt", Version: 1,
+	})
+	if err != nil {
+		t.Fatalf("PresignLoad v1: %v", err)
+	}
+	if resp.Version != 1 {
+		t.Fatalf("Version = %d, want 1", resp.Version)
+	}
+}
+
+func TestPresignLoadUsesRequestTTL(t *testing.T) {
+	fake := newFakeS3()
+	presigner := &fakePresigner{}
+	svc := newTestService(t, fake, Config{Bucket: "b", Presigner: presigner, PresignTTL: time.Hour})
+	saveText(t, svc, "report.txt", "x")
+
+	want := 5 * time.Minute
+	if _, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt",
+		TTL: want,
+	}); err != nil {
+		t.Fatalf("PresignLoad: %v", err)
+	}
+	if got := presigner.calls[0].ttl; got != want {
+		t.Fatalf("ttl = %v, want %v", got, want)
+	}
+}
+
+func TestPresignLoadUsesConfigTTL(t *testing.T) {
+	fake := newFakeS3()
+	presigner := &fakePresigner{}
+	want := 2 * time.Hour
+	svc := newTestService(t, fake, Config{Bucket: "b", Presigner: presigner, PresignTTL: want})
+	saveText(t, svc, "report.txt", "x")
+
+	if _, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt",
+	}); err != nil {
+		t.Fatalf("PresignLoad: %v", err)
+	}
+	if got := presigner.calls[0].ttl; got != want {
+		t.Fatalf("ttl = %v, want %v (Config.PresignTTL)", got, want)
+	}
+}
+
+func TestPresignLoadDefaultsTTLTo15Minutes(t *testing.T) {
+	fake := newFakeS3()
+	presigner := &fakePresigner{}
+	svc := newTestService(t, fake, Config{Bucket: "b", Presigner: presigner})
+	saveText(t, svc, "report.txt", "x")
+
+	if _, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt",
+	}); err != nil {
+		t.Fatalf("PresignLoad: %v", err)
+	}
+	if got := presigner.calls[0].ttl; got != defaultPresignTTL {
+		t.Fatalf("ttl = %v, want %v (default)", got, defaultPresignTTL)
+	}
+}
+
+func TestPresignLoadErrorsWithoutPresigner(t *testing.T) {
+	svc := newTestService(t, newFakeS3(), Config{Bucket: "b"})
+	_, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "report.txt",
+	})
+	if err == nil {
+		t.Fatal("want error when Presigner not configured")
+	}
+}
+
+func TestPresignLoadErrorsWhenArtifactNotFound(t *testing.T) {
+	presigner := &fakePresigner{}
+	svc := newTestService(t, newFakeS3(), Config{Bucket: "b", Presigner: presigner})
+	_, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "nope.txt",
+	})
+	if !isFSNotExist(err) {
+		t.Fatalf("want fs.ErrNotExist, got %v", err)
+	}
+}
+
+func TestPresignLoadPassesBucketToPresigner(t *testing.T) {
+	fake := newFakeS3()
+	presigner := &fakePresigner{}
+	svc := newTestService(t, fake, Config{Bucket: "my-bucket", Presigner: presigner})
+	saveText(t, svc, "f.txt", "x")
+
+	if _, err := svc.PresignLoad(context.Background(), &PresignLoadRequest{
+		AppName: "app", UserID: "u1", SessionID: "s1", FileName: "f.txt",
+	}); err != nil {
+		t.Fatalf("PresignLoad: %v", err)
+	}
+	if presigner.calls[0].bucket != "my-bucket" {
+		t.Fatalf("bucket = %q, want my-bucket", presigner.calls[0].bucket)
+	}
+}

--- a/artifact/s3/service.go
+++ b/artifact/s3/service.go
@@ -76,6 +76,12 @@ type Config struct {
 	// SSEKMSKeyID, when set, enables SSE-KMS with this key on every write.
 	// When empty, writes rely on the bucket's default encryption settings.
 	SSEKMSKeyID string
+	// Presigner, when set, enables [Service.PresignLoad]. Use
+	// [PresignClientAdapter] to wrap *s3.PresignClient.
+	Presigner Presigner
+	// PresignTTL is the default TTL applied by [Service.PresignLoad].
+	// Defaults to 15 minutes when zero.
+	PresignTTL time.Duration
 }
 
 // Service is an S3-backed [artifact.Service].

--- a/examples/bedrock-artifact-s3/README.md
+++ b/examples/bedrock-artifact-s3/README.md
@@ -1,18 +1,27 @@
 # S3 artifact service
 
-Persists ADK artifacts in Amazon S3 via [`artifact/s3`](../../artifact/s3), instead of the in-memory service the other examples use. The program wires the service the same way you would in `runner.Config{ArtifactService: ...}`, then saves and reloads a text artifact to show the round trip.
+Persists ADK artifacts in Amazon S3 via [`artifact/s3`](../../artifact/s3), instead of the in-memory service the other examples use. The program wires the service the same way you would in `runner.Config{ArtifactService: ...}`, then saves an artifact, reloads it, and generates a pre-signed 15-minute GET URL.
 
 Objects are stored one-per-version under `[prefix/]appName/userID/sessionID/fileName/version` (and `.../userID/user/...` for `user:`-scoped filenames), mirroring ADK's upstream GCS artifact service.
 
 ## Requirements
 
 - AWS credentials via the default chain
-- An S3 bucket you can read/write: `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket` on the configured prefix (plus KMS permissions if you set `SSEKMSKeyID`)
+- An S3 bucket you can read/write: `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket` on the bucket (plus KMS permissions if you set `SSEKMSKeyID`)
 
 ## Run
 
 ```bash
 export ARTIFACT_S3_BUCKET=my-artifacts-bucket
 export ARTIFACT_S3_PREFIX=adk-artifacts   # optional
-make run
+go run ./examples/bedrock-artifact-s3
+```
+
+## Expected output
+
+```
+saved "greeting.txt" version 1
+loaded: hello from S3-backed artifacts
+pre-signed URL (expires 2026-07-07T16:15:00Z):
+https://my-artifacts-bucket.s3.eu-west-1.amazonaws.com/greeting.txt/1?X-Amz-…
 ```

--- a/examples/bedrock-artifact-s3/README.md
+++ b/examples/bedrock-artifact-s3/README.md
@@ -7,7 +7,7 @@ Objects are stored one-per-version under `[prefix/]appName/userID/sessionID/file
 ## Requirements
 
 - AWS credentials via the default chain
-- An S3 bucket you can read/write: `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket` on the bucket (plus KMS permissions if you set `SSEKMSKeyID`)
+- An S3 bucket you can read/write: `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket` on the configured prefix (plus KMS permissions if you set `SSEKMSKeyID`)
 
 ## Run
 

--- a/examples/bedrock-artifact-s3/main.go
+++ b/examples/bedrock-artifact-s3/main.go
@@ -1,7 +1,7 @@
 // S3 artifact service example for adk-go-bedrock: wires the artifact/s3
 // [artifact.Service] into an ADK runner so agent/tool artifacts persist in
-// Amazon S3 instead of process memory, then saves and reloads an artifact
-// directly to show the round trip.
+// Amazon S3 instead of process memory, then saves, reloads, and generates a
+// pre-signed download URL for an artifact to show the full round trip.
 //
 // Authenticate with AWS using the default credential chain and set:
 //
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -41,9 +42,14 @@ func main() {
 		log.Fatalf("load AWS config: %v", err)
 	}
 
-	svc, err := s3artifact.NewService(s3.NewFromConfig(awsCfg), s3artifact.Config{
+	s3Client := s3.NewFromConfig(awsCfg)
+
+	svc, err := s3artifact.NewService(s3Client, s3artifact.Config{
 		Bucket:    bucket,
 		KeyPrefix: os.Getenv("ARTIFACT_S3_PREFIX"),
+		// Wire up pre-signed URL support.
+		Presigner:  s3artifact.PresignClientAdapter{Client: s3.NewPresignClient(s3Client)},
+		PresignTTL: 15 * time.Minute,
 	})
 	if err != nil {
 		log.Fatalf("create artifact service: %v", err)
@@ -69,14 +75,23 @@ func main() {
 	if err != nil {
 		log.Fatalf("save artifact: %v", err)
 	}
-	fmt.Printf("saved greeting.txt version %d\n", saved.Version)
+	fmt.Printf("saved %q version %d\n", "greeting.txt", saved.Version)
 
 	loaded, err := svc.Load(ctx, &artifact.LoadRequest{
 		AppName: "artifact-s3-example", UserID: "demo-user", SessionID: "demo-session",
-		FileName: "greeting.txt", // Version 0 = latest
+		FileName: "greeting.txt",
 	})
 	if err != nil {
 		log.Fatalf("load artifact: %v", err)
 	}
 	fmt.Printf("loaded: %s\n", loaded.Part.InlineData.Data)
+
+	signed, err := svc.PresignLoad(ctx, &s3artifact.PresignLoadRequest{
+		AppName: "artifact-s3-example", UserID: "demo-user", SessionID: "demo-session",
+		FileName: "greeting.txt",
+	})
+	if err != nil {
+		log.Fatalf("presign: %v", err)
+	}
+	fmt.Printf("pre-signed URL (expires %s):\n%s\n", signed.Expires.Format(time.RFC3339), signed.URL)
 }


### PR DESCRIPTION
Stacked on #131.

### What this adds

`PresignLoad` on the S3 artifact service — generates a pre-signed S3 GET URL so callers can hand a direct-download link to a client without streaming bytes through the application.

### New surface (`artifact/s3/presign.go`)

| Symbol | Purpose |
|---|---|
| `Presigner` | Interface: `PresignGetObject(ctx, bucket, key, ttl) (string, error)` |
| `PresignClientAdapter` | Wraps `*s3.PresignClient` to satisfy `Presigner` |
| `PresignLoadRequest` | Input: coordinates + optional `Version` (0 = latest) + optional per-request `TTL` |
| `PresignLoadResponse` | Output: `URL`, resolved `Version`, approximate `Expires` |
| `Service.PresignLoad` | Method on the existing `Service` |

### TTL precedence

`PresignLoadRequest.TTL` → `Config.PresignTTL` → 15 min default

### Opt-in

`Config.Presigner` defaults to nil. Existing callers that do not set it are unaffected; `PresignLoad` returns an error if called without a presigner.

### Usage

```go
pc := s3.NewPresignClient(s3Client)
svc, _ := s3artifact.NewService(s3Client, s3artifact.Config{
    Bucket:    "my-bucket",
    Presigner: s3artifact.PresignClientAdapter{Client: pc},
    PresignTTL: time.Hour,
})

resp, err := svc.PresignLoad(ctx, &s3artifact.PresignLoadRequest{
    AppName: "my-app", UserID: "u1", SessionID: "s1",
    FileName: "report.pdf", // Version 0 = latest
})
// resp.URL is a signed https://… valid until resp.Expires
```

### Testing:
```
natedev@MB-J502JJWVXT bedrock-artifact-s3 % make run                                                        
go run .
saved "greeting.txt" version 4
loaded: hello from S3-backed artifacts
pre-signed URL (expires 2026-07-07T17:10:35+01:00):
https://REDACTED_PRESIGNED_URL```

Opening that:
<img width="1915" height="925" alt="image" src="https://github.com/user-attachments/assets/ba049048-3a04-46bc-bd90-a9ea3f6f0770" />
