### PR TITLE
ci: scan fork pull requests with CodeQL

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "31 20 * * 6"
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -36,6 +36,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:


### PR DESCRIPTION
## Summary

- add an advanced CodeQL workflow for Go and GitHub Actions
- scan all pull requests targeting `main`, including pull requests from forks
- retain push, weekly, and manual scans
- avoid path filters so the required CodeQL check is always produced

## Migration status

- CodeQL default setup was disabled on 2026-08-31
- the advanced workflow was rerun successfully for both `actions` and `go`
- after this merges, run the workflow manually once and reopen or synchronize PR #159 to trigger its fork-safe `pull_request` scan

The workflow intentionally uses `pull_request`, not `pull_request_target`, so untrusted fork code receives no repository secrets or write-capable token.

## Validation

- `go test ./... -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/codeql.yaml`
- `git diff --check`